### PR TITLE
`jellyfish-transaction-signature` - refactor TransactionSigner

### DIFF
--- a/packages/jellyfish-transaction-signature/__tests__/tx_signature/sign_input.test.ts
+++ b/packages/jellyfish-transaction-signature/__tests__/tx_signature/sign_input.test.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { OP_CODES, OP_PUSHDATA, SIGHASH, Transaction, Vout } from '@defichain/jellyfish-transaction'
 import { SHA256, HASH160, Elliptic } from '@defichain/jellyfish-crypto'
-import { TransactionSigner } from '../../src'
+import { SegWitSigner } from '../../src'
 
 describe('sign single input', () => {
   const transaction: Transaction = {
@@ -70,7 +70,7 @@ describe('sign single input', () => {
   const keyPair = Elliptic.fromPrivKey(privateKey)
 
   it('should sign single input', async () => {
-    const witness = await TransactionSigner.signInput(transaction, 1, {
+    const witness = await SegWitSigner.signInput(transaction, 1, {
       prevout: prevout,
       ellipticPair: keyPair
     }, SIGHASH.ALL)
@@ -85,7 +85,7 @@ describe('sign single input', () => {
   })
 
   it('should sign with same witnessScript getting the same signature', async () => {
-    const witness = await TransactionSigner.signInput(transaction, 1, {
+    const witness = await SegWitSigner.signInput(transaction, 1, {
       prevout: prevout,
       ellipticPair: keyPair,
       witnessScript: {
@@ -109,7 +109,7 @@ describe('sign single input', () => {
   })
 
   it('should sign with different witness script getting different signature', async () => {
-    const witness = await TransactionSigner.signInput(transaction, 1, {
+    const witness = await SegWitSigner.signInput(transaction, 1, {
       prevout: prevout,
       ellipticPair: keyPair,
       witnessScript: {
@@ -133,7 +133,7 @@ describe('sign single input', () => {
   })
 
   it('should fail as P2WSH cannot be guessed', async () => {
-    return await expect(TransactionSigner.signInput(transaction, 1, {
+    return await expect(SegWitSigner.signInput(transaction, 1, {
       prevout: {
         script: {
           stack: [
@@ -150,7 +150,7 @@ describe('sign single input', () => {
   })
 
   it('should fail as isV0P2WPKH cannot match provided prevout ', async () => {
-    return await expect(TransactionSigner.signInput(transaction, 1, {
+    return await expect(SegWitSigner.signInput(transaction, 1, {
       prevout: {
         script: {
           stack: [
@@ -169,42 +169,42 @@ describe('sign single input', () => {
 
   describe('SIGHASH for consistency should err-out as they are not implemented', () => {
     it('should err SIGHASH.NONE', async () => {
-      return await expect(TransactionSigner.signInput(transaction, 1, {
+      return await expect(SegWitSigner.signInput(transaction, 1, {
         prevout: prevout,
         ellipticPair: keyPair
       }, SIGHASH.NONE)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
 
     it('should err SIGHASH.SINGLE', async () => {
-      return await expect(TransactionSigner.signInput(transaction, 1, {
+      return await expect(SegWitSigner.signInput(transaction, 1, {
         prevout: prevout,
         ellipticPair: keyPair
       }, SIGHASH.SINGLE)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
 
     it('should err SIGHASH.ANYONECANPAY', async () => {
-      return await expect(TransactionSigner.signInput(transaction, 1, {
+      return await expect(SegWitSigner.signInput(transaction, 1, {
         prevout: prevout,
         ellipticPair: keyPair
       }, SIGHASH.ANYONECANPAY)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
 
     it('should err SIGHASH.ALL_ANYONECANPAY', async () => {
-      return await expect(TransactionSigner.signInput(transaction, 1, {
+      return await expect(SegWitSigner.signInput(transaction, 1, {
         prevout: prevout,
         ellipticPair: keyPair
       }, SIGHASH.ALL_ANYONECANPAY)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
 
     it('should err SIGHASH.NONE_ANYONECANPAY', async () => {
-      return await expect(TransactionSigner.signInput(transaction, 1, {
+      return await expect(SegWitSigner.signInput(transaction, 1, {
         prevout: prevout,
         ellipticPair: keyPair
       }, SIGHASH.NONE_ANYONECANPAY)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
 
     it('should err SIGHASH.SINGLE_ANYONECANPAY', async () => {
-      return await expect(TransactionSigner.signInput(transaction, 1, {
+      return await expect(SegWitSigner.signInput(transaction, 1, {
         prevout: prevout,
         ellipticPair: keyPair
       }, SIGHASH.SINGLE_ANYONECANPAY)).rejects.toThrow('currently only SIGHASH.ALL is supported')

--- a/packages/jellyfish-transaction-signature/src/index.ts
+++ b/packages/jellyfish-transaction-signature/src/index.ts
@@ -1,1 +1,2 @@
 export * from './tx_signature'
+export * from './segwit_signature'

--- a/packages/jellyfish-transaction-signature/src/segwit_signature.ts
+++ b/packages/jellyfish-transaction-signature/src/segwit_signature.ts
@@ -1,0 +1,226 @@
+import { dSHA256, HASH160, EllipticPair } from '@defichain/jellyfish-crypto'
+import { SmartBuffer } from 'smart-buffer'
+import {
+  Script,
+  Transaction,
+  TransactionSegWit,
+  Vin,
+  Vout,
+  Witness,
+  OP_CODES,
+  OP_PUSHDATA,
+  CWitnessProgram,
+  WitnessProgram,
+  DeFiTransactionConstants,
+  SIGHASH,
+  CVoutV4
+} from '@defichain/jellyfish-transaction'
+import {
+  SignOption
+} from './tx_signature'
+
+export interface SignInputOption {
+  /**
+   * Prevout of this input
+   */
+  prevout: Vout
+  /**
+   * EllipticPair to generate a signature with
+   */
+  ellipticPair: EllipticPair
+  /**
+   * Optionally provide a witness script,
+   * or it will be guessed if it can be guessed.
+   */
+  witnessScript?: Script
+}
+
+function hashPrevouts (transaction: Transaction, sigHashType: SIGHASH): string {
+  if (sigHashType !== SIGHASH.ALL) {
+    throw new Error('currently only SIGHASH.ALL is supported')
+  }
+
+  const buffer = new SmartBuffer()
+  for (const vin of transaction.vin) {
+    const txid = Buffer.from(vin.txid, 'hex').reverse()
+    buffer.writeBuffer(txid)
+    buffer.writeUInt32LE(vin.index)
+  }
+  return dSHA256(buffer.toBuffer()).toString('hex')
+}
+
+function hashSequence (transaction: Transaction, sigHashType: SIGHASH): string {
+  if (sigHashType !== SIGHASH.ALL) {
+    throw new Error('currently only SIGHASH.ALL is supported')
+  }
+
+  const buffer = new SmartBuffer()
+  for (const vin of transaction.vin) {
+    buffer.writeUInt32LE(vin.sequence)
+  }
+  return dSHA256(buffer.toBuffer()).toString('hex')
+}
+
+function hashOutputs (transaction: Transaction, sigHashType: SIGHASH): string {
+  if (sigHashType !== SIGHASH.ALL) {
+    throw new Error('currently only SIGHASH.ALL is supported')
+  }
+
+  const buffer = new SmartBuffer()
+  transaction.vout.forEach(vout => (new CVoutV4(vout)).toBuffer(buffer))
+  return dSHA256(buffer.toBuffer()).toString('hex')
+}
+
+/**
+ *
+ * The witness must consist of exactly 2 items.
+ * The '0' in scriptPubKey indicates the following push is a version 0 witness program.
+ * The length of 20 indicates that it is a P2WPKH type.
+ *
+ * @param {SignInputOption} signInputOption to check is is V0 P2WPKH
+ */
+async function isV0P2WPKH (signInputOption: SignInputOption): Promise<boolean> {
+  const stack = signInputOption.prevout.script.stack
+
+  if (stack.length === 2 && stack[1] instanceof OP_PUSHDATA &&
+    (stack[1] as OP_PUSHDATA).length() === 20 // p2wpkh ELSE p2wsh
+  ) {
+    const pubkey: Buffer = await signInputOption.ellipticPair.publicKey()
+    const pubkeyHashHex = HASH160(pubkey).toString('hex')
+    const pushDataHex = (stack[1] as OP_PUSHDATA).hex
+
+    if (pubkeyHashHex === pushDataHex) {
+      return true
+    }
+
+    throw new Error('invalid input option - attempting to sign a mismatch vout and elliptic pair is not allowed')
+  }
+
+  return false
+}
+
+/**
+ * If script is not provided, it needs to be guessed
+ *
+ * @param {Vin} vin of the script
+ * @param {SignInputOption} signInputOption to sign the vin
+ */
+async function getScriptCode (signInputOption: SignInputOption): Promise<Script> {
+  if (signInputOption.witnessScript !== undefined) {
+    return signInputOption.witnessScript
+  }
+
+  if (await isV0P2WPKH(signInputOption)) {
+    const pubkey: Buffer = await signInputOption.ellipticPair.publicKey()
+    const pubkeyHash = HASH160(pubkey)
+
+    return {
+      stack: [
+        OP_CODES.OP_DUP,
+        OP_CODES.OP_HASH160,
+        OP_CODES.OP_PUSHDATA(pubkeyHash, 'little'),
+        OP_CODES.OP_EQUALVERIFY,
+        OP_CODES.OP_CHECKSIG
+      ]
+    }
+  }
+
+  throw new Error('witnessScript required, only P2WPKH can be guessed')
+}
+
+async function asWitnessProgram (transaction: Transaction, vin: Vin, signInputOption: SignInputOption, sigHashType: SIGHASH): Promise<WitnessProgram> {
+  return {
+    version: transaction.version,
+    hashPrevouts: hashPrevouts(transaction, sigHashType),
+    hashSequence: hashSequence(transaction, sigHashType),
+    outpointTxId: vin.txid,
+    outpointIndex: vin.index,
+    scriptCode: await getScriptCode(signInputOption),
+    value: signInputOption.prevout.value,
+    sequence: vin.sequence,
+    hashOutputs: hashOutputs(transaction, sigHashType),
+    lockTime: transaction.lockTime,
+    hashType: sigHashType
+  }
+}
+
+/**
+ * TransactionSigner
+ * 1. you can sign an unsigned transaction and get a signed transaction.
+ * 2. you can sign a vin and get a witness in tx for that vin
+ *
+ * https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki
+ * https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
+ * https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki
+ */
+export const SegWitSigner = {
+
+  /**
+   * @param {Transaction} transaction to sign
+   * @param {number} index of the vin to sign
+   * @param {SignInputOption} option input option
+   * @param {SIGHASH} sigHashType SIGHASH type
+   */
+  async signInput (transaction: Transaction, index: number, option: SignInputOption, sigHashType: SIGHASH = SIGHASH.ALL): Promise<Witness> {
+    const vin = transaction.vin[index]
+    const program = await asWitnessProgram(transaction, vin, option, sigHashType)
+    const preimage = new CWitnessProgram(program).asBuffer()
+    const sigHash = dSHA256(preimage)
+    const derSignature = await option.ellipticPair.sign(sigHash)
+    const sigHashBuffer = Buffer.alloc(1, sigHashType)
+
+    // signature + pubKey
+    const signature = Buffer.concat([derSignature, Buffer.alloc(1, sigHashBuffer)])
+    const pubkey: Buffer = await option.ellipticPair.publicKey()
+    return {
+      scripts: [
+        {
+          hex: signature.toString('hex')
+        },
+        {
+          hex: pubkey.toString('hex')
+        }
+      ]
+    }
+  },
+
+  async sign (transaction: Transaction, inputOptions: SignInputOption[], option: SignOption = {}): Promise<TransactionSegWit> {
+    const { sigHashType = SIGHASH.ALL } = option
+
+    const witnesses: Witness[] = []
+    for (let i = 0; i < transaction.vin.length; i++) {
+      const witness = await this.signInput(transaction, i, inputOptions[i], sigHashType)
+      witnesses.push(witness)
+    }
+
+    return {
+      version: transaction.version,
+      marker: DeFiTransactionConstants.WitnessMarker,
+      flag: DeFiTransactionConstants.WitnessFlag,
+      vin: transaction.vin,
+      vout: transaction.vout,
+      witness: witnesses,
+      lockTime: transaction.lockTime
+    }
+  },
+
+  validate (transaction: Transaction, inputOptions: SignInputOption[], option: SignOption) {
+    const { version = true, lockTime = true } = (option.validate !== undefined) ? option.validate : {}
+
+    if (transaction.vin.length === 0) {
+      throw new Error('vin.length = 0 - attempting to sign transaction without vin is not allowed')
+    }
+
+    if (transaction.vin.length !== inputOptions.length) {
+      throw new Error('vin.length and inputOptions.length must match')
+    }
+
+    if (version && transaction.version !== DeFiTransactionConstants.Version) {
+      throw new Error(`option.validate.version = true - trying to sign a txn ${transaction.version} different from ${DeFiTransactionConstants.Version} is not supported`)
+    }
+
+    if (lockTime && transaction.lockTime !== 0) {
+      throw new Error(`option.validate.lockTime = true - lockTime: ${transaction.lockTime} must be zero`)
+    }
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:
Refactor segwit signer, tx_signature be the agnostic layer, structure ready for other non segwit vin signing

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
Longer term, lower priority task, for `jellyfish-transaction-signature` to support signing all p2pkh, p2pk, p2sh inputs still has long way to go. Most likely only tackle after `jellyfish-wallet-encrypted` is ready.