### PR TITLE
updated npm badge to use jellyfish-network for more accurate versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI](https://github.com/DeFiCh/jellyfish/actions/workflows/ci.yml/badge.svg)](https://github.com/DeFiCh/jellyfish/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/DeFiCh/jellyfish/branch/main/graph/badge.svg?token=IYL9K0WROA)](https://codecov.io/gh/DeFiCh/jellyfish)
 [![Maintainability](https://api.codeclimate.com/v1/badges/7019f1d74a0500951b2a/maintainability)](https://codeclimate.com/github/DeFiCh/jellyfish/maintainability)
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish)](https://www.npmjs.com/package/@defichain/jellyfish)
+[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-network)](https://www.npmjs.com/package/@defichain/jellyfish-network)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/c5b7a65e-aeec-4e12-a7b7-300cbc1a8069/deploy-status)](https://app.netlify.com/sites/cranky-franklin-5e59ef/deploys)
 
 # [@defichain/jellyfish](https://jellyfish.defichain.com)
@@ -27,8 +27,6 @@ We are consolidating all jellyfish ecosystem projects ocean, whale, playground, 
 
 DeFi Jellyfish follows a monorepo methodology, all maintained packages are in the same repo and published with the same
 version tag.
-
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish)](https://www.npmjs.com/package/@defichain/jellyfish/v/latest)
 
 Package                                            | Description
 ---------------------------------------------------|-------------

--- a/docs/ecosystem/01-introduction.md
+++ b/docs/ecosystem/01-introduction.md
@@ -17,8 +17,6 @@ test.
 As with all modern JavaScript projects, jellyfish follows a monorepo structure with its concerns separated. All packages
 maintained in this repo are published with the same version tag and follows the `DeFiCh/ain` releases.
 
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish)](https://www.npmjs.com/package/@defichain/jellyfish/v/latest)
-
 Package                                            | Description
 ---------------------------------------------------|-------------
 `@defichain/jellyfish-address`                     | Provide address builder, parser, validator utility library for DeFi Blockchain.

--- a/packages/jellyfish-address/README.md
+++ b/packages/jellyfish-address/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-address)](https://www.npmjs.com/package/@defichain/jellyfish-address/v/latest)
-
 # @defichain/jellyfish-address
 
 All in one DeFiChain from script to address, address to script parser.

--- a/packages/jellyfish-api-core/README.md
+++ b/packages/jellyfish-api-core/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-api-core)](https://www.npmjs.com/package/@defichain/jellyfish-api-core/v/latest)
-
 # @defichain/jellyfish-api-core
 
 `@defichain/jellyfish-api-core` is a protocol agnostic DeFiChain client implementation with APIs separated into their

--- a/packages/jellyfish-api-jsonrpc/README.md
+++ b/packages/jellyfish-api-jsonrpc/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-api-jsonrpc)](https://www.npmjs.com/package/@defichain/jellyfish-api-jsonrpc/v/latest)
-
 # @defichain/jellyfish-api-jsonrpc
 
 `@defichain/jellyfish-api-jsonrpc` implements `@defichain/jellyfish-api-core`

--- a/packages/jellyfish-block/README.md
+++ b/packages/jellyfish-block/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-block)](https://www.npmjs.com/package/@defichain/jellyfish-block/v/latest)
-
 # @defichain/jellyfish-block
 
 Stateless raw block composer for the DeFi Blockchain.

--- a/packages/jellyfish-buffer/README.md
+++ b/packages/jellyfish-buffer/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-buffer)](https://www.npmjs.com/package/@defichain/jellyfish-buffer/v/latest)
-
 # @defichain/jellyfish-buffer
 
 DeFi Blockchain buffer composer.

--- a/packages/jellyfish-crypto/README.md
+++ b/packages/jellyfish-crypto/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-crypto)](https://www.npmjs.com/package/@defichain/jellyfish-crypto/v/latest)
-
 # @defichain/jellyfish-crypto
 
 Cryptography operations for jellyfish, includes a simple `secp256k1` `EllipticPair`.

--- a/packages/jellyfish-json/README.md
+++ b/packages/jellyfish-json/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-json)](https://www.npmjs.com/package/@defichain/jellyfish-json/v/latest)
-
 # @defichain/jellyfish-json
 
 `JellyfishJSON` allows parsing of JSON with `'lossless'`, `'bignumber'` and `'number'` numeric precision.

--- a/packages/jellyfish-network/README.md
+++ b/packages/jellyfish-network/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-network)](https://www.npmjs.com/package/@defichain/jellyfish-network/v/latest)
-
 # @defichain/jellyfish-network
 
 DeFi Blockchain various network configuration for main, net and regtest.

--- a/packages/jellyfish-testing/README.md
+++ b/packages/jellyfish-testing/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-testing)](https://www.npmjs.com/package/@defichain/jellyfish-testing/v/latest)
-
 # @defichain/jellyfish-testing
 
 This package introduces a centralized testing framework for the jellyfish replacing the existing `@defichain/testing`.

--- a/packages/jellyfish-transaction-builder/README.md
+++ b/packages/jellyfish-transaction-builder/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-transaction-builder)](https://www.npmjs.com/package/@defichain/jellyfish-transaction-builder/v/latest)
-
 # @defichain/jellyfish-transaction-builder
 
 While jellyfish-transaction provides a dead simple, modern, stateless raw transaction builder for DeFi. Constructing a

--- a/packages/jellyfish-transaction-signature/README.md
+++ b/packages/jellyfish-transaction-signature/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-transaction-signature)](https://www.npmjs.com/package/@defichain/jellyfish-transaction-signature/v/latest)
-
 # @defichain/jellyfish-transaction-signature
 
 Stateless utility library to perform transaction signing.

--- a/packages/jellyfish-transaction/README.md
+++ b/packages/jellyfish-transaction/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-transaction)](https://www.npmjs.com/package/@defichain/jellyfish-transaction/v/latest)
-
 # @defichain/jellyfish-transaction
 
 Dead simple modern stateless raw transaction composer for the DeFi Blockchain.

--- a/packages/jellyfish-wallet-classic/README.md
+++ b/packages/jellyfish-wallet-classic/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-wallet-classic)](https://www.npmjs.com/package/@defichain/jellyfish-wallet-classic/v/latest)
-
 # @defichain/jellyfish-wallet-classic
 
 WalletClassic implements a simple, single elliptic pair wallet.

--- a/packages/jellyfish-wallet-encrypted/README.md
+++ b/packages/jellyfish-wallet-encrypted/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-wallet-encrypted)](https://www.npmjs.com/package/@defichain/jellyfish-wallet-encrypted/v/latest)
-
 # @defichain/jellyfish-wallet-encrypted
 
 EncryptedMnemonicHdNode extends MnemonicHdNode to implement promise-based privKey resolution. This allows latent based

--- a/packages/jellyfish-wallet-mnemonic/README.md
+++ b/packages/jellyfish-wallet-mnemonic/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-wallet-mnemonic)](https://www.npmjs.com/package/@defichain/jellyfish-wallet-mnemonic/v/latest)
-
 # @defichain/jellyfish-wallet-mnemonic
 
 MnemonicHdNode implements the WalletHdNode from jellyfish-wallet. HdNode implementations is purpose and derivation

--- a/packages/jellyfish-wallet/README.md
+++ b/packages/jellyfish-wallet/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-wallet)](https://www.npmjs.com/package/@defichain/jellyfish-wallet/v/latest)
-
 # @defichain/jellyfish-wallet
 
 > If you want to use multiple/change address please use defid directly.

--- a/packages/testcontainers/README.md
+++ b/packages/testcontainers/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/testcontainers)](https://www.npmjs.com/package/@defichain/testcontainers/v/latest)
-
 # @defichain/testcontainers
 
 Similar to [testcontainers](https://www.testcontainers.org/) in the Java ecosystem, this package provides a lightweight,

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,5 +1,3 @@
-[![npm](https://img.shields.io/npm/v/@defichain/testing)](https://www.npmjs.com/package/@defichain/testing/v/latest)
-
 # @defichain/testing
 
 Testing is an essential part of any serious quality software developer work. This package provides many abstractions for


### PR DESCRIPTION
also removed badge in individual packages

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore