### PR TITLE
Improve RPC 403 error handling

### DIFF
--- a/packages/jellyfish-api-jsonrpc/src/index.ts
+++ b/packages/jellyfish-api-jsonrpc/src/index.ts
@@ -59,6 +59,7 @@ export class JsonRpcClient extends ApiClient {
 
     switch (response.status) {
       case 401:
+      case 403:
       case 404:
         throw new ClientApiError(`${response.status} - ${response.statusText}`)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind fix
-->

/kind fix

#### What this PR does / why we need it:
Throw error when RPC server reports 403 status instead of proceeding to parsing empty response and getting parsing error.


#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
No issue created

#### Additional comments?:
<img width="854" alt="Screenshot 2021-10-29 at 15 29 11" src="https://user-images.githubusercontent.com/548534/139439075-c6e6ce4e-dcb9-422e-a988-6204a1d569d9.png">