### PR TITLE
feat(jellyfish-api-core): invalidate- and reconsiderBlock rpc

### DIFF
--- a/docs/node/CATEGORIES/01-blockchain.md
+++ b/docs/node/CATEGORIES/01-blockchain.md
@@ -371,3 +371,25 @@ interface WaitBlockResult {
   height: number
 }
 ```
+
+## invalidateBlock
+
+Permanently marks a block as invalid, as if it violated a consensus rule.
+
+```ts title="client.blockchain.invalidateBlock()"
+interface blockchain {
+  invalidateBlock(hash: string): Promise<void>
+}
+```
+
+## reconsiderBlock
+
+Removes invalidity status of a block, its ancestors and its descendants, reconsider them for activation.
+
+```ts title="client.blockchain.reconsiderBlock()"
+interface blockchain {
+  reconsiderBlock(hash: string): Promise<void>
+}
+```
+
+

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/invalidateBlock.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/invalidateBlock.test.ts
@@ -1,0 +1,32 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { Testing } from '@defichain/jellyfish-testing'
+import { RpcApiError } from '../../../src'
+
+describe('InvalidateBlock', () => {
+  const testing = Testing.create(new MasterNodeRegTestContainer())
+
+  beforeAll(async () => {
+    await testing.container.start()
+  })
+
+  afterAll(async () => {
+    await testing.container.stop()
+  })
+
+  it('should throw an error for the invalid hash length', async () => {
+    const promise = testing.rpc.blockchain.invalidateBlock('12345678')
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('RpcApiError: \'blockhash must be of length 64 (not 8, for \'12345678\')\', code: -8, method: invalidateblock')
+  })
+
+  it('should throw an error for the non-existing valid hash', async () => {
+    const promise = testing.rpc.blockchain.invalidateBlock('x'.repeat(64))
+    await expect(promise).rejects.toThrow('RpcApiError: \'blockhash must be hexadecimal string (not \'' + 'x'.repeat(64) + '\')\', code: -8, method: invalidateblock')
+  })
+
+  it('should resolve promise with null for existing hash', async () => {
+    const hash = await testing.misc.waitForBlockHash(1)
+    const promise = testing.rpc.blockchain.invalidateBlock(hash)
+    await expect(promise).resolves.toBeNull()
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/reconsiderBlock.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/reconsiderBlock.test.ts
@@ -1,0 +1,32 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { Testing } from '@defichain/jellyfish-testing'
+import { RpcApiError } from '../../../src'
+
+describe('ReconsiderBlock', () => {
+  const testing = Testing.create(new MasterNodeRegTestContainer())
+
+  beforeAll(async () => {
+    await testing.container.start()
+  })
+
+  afterAll(async () => {
+    await testing.container.stop()
+  })
+
+  it('should throw an error for the invalid hash length', async () => {
+    const promise = testing.rpc.blockchain.reconsiderBlock('12345678')
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('RpcApiError: \'blockhash must be of length 64 (not 8, for \'12345678\')\', code: -8, method: reconsiderblock')
+  })
+
+  it('should throw an error for the non-existing valid hash', async () => {
+    const promise = testing.rpc.blockchain.reconsiderBlock('x'.repeat(64))
+    await expect(promise).rejects.toThrow('RpcApiError: \'blockhash must be hexadecimal string (not \'' + 'x'.repeat(64) + '\')\', code: -8, method: reconsiderblock')
+  })
+
+  it('should resolve promise with null for existing hash', async () => {
+    const hash = await testing.misc.waitForBlockHash(1)
+    const promise = testing.rpc.blockchain.reconsiderBlock(hash)
+    await expect(promise).resolves.toBeNull()
+  })
+})

--- a/packages/jellyfish-api-core/src/category/blockchain.ts
+++ b/packages/jellyfish-api-core/src/category/blockchain.ts
@@ -214,6 +214,28 @@ export class Blockchain {
   async waitForBlockHeight (height: number, timeout: number = 30000): Promise<WaitBlockResult> {
     return await this.client.call('waitforblockheight', [height, timeout], 'number')
   }
+
+  /**
+   * Permanently marks a block as invalid, as if it violated a consensus rule.
+   *
+   *
+   * @param {string} hash of the block to mark as invalid
+   * @return Promise<void>
+   */
+  async invalidateBlock (hash: string): Promise<void> {
+    return await this.client.call('invalidateblock', [hash], 'number')
+  }
+
+  /**
+   * Removes invalidity status of a block, its ancestors and its descendants, reconsider them for activation.
+   *
+   *
+   * @param {string} hash of the block to reconsider
+   * @return Promise<void>
+   */
+  async reconsiderBlock (hash: string): Promise<void> {
+    return await this.client.call('reconsiderblock', [hash], 'number')
+  }
 }
 
 /**


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### Which issue(s) does this PR fixes?:
Fixes part of #48

#### What this PR does / why we need it:
Implemented RPC from #48:
1. blockchain.invalidateBlock
2. blockchain.reconsiderBlock
