### PR TITLE
feat(jellyfish-testing): created testingwrapper as an abstraction layer 

### DIFF
--- a/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
+++ b/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
@@ -23,7 +23,7 @@ describe('create a single test container using testwrapper', () => {
   })
 
   it('should be able to create regtest non masternode container', async () => {
-    testing = testingWrapper.create(1, index => new RegTestContainer()) as Testing
+    testing = testingWrapper.create(1, () => new RegTestContainer())
     await testing.container.start()
 
     // call rpc
@@ -37,7 +37,7 @@ describe('create a single test container using testwrapper', () => {
   })
 
   it('should be able to create mainnet container', async () => {
-    testing = testingWrapper.create(1, index => new MainNetContainer()) as Testing
+    testing = testingWrapper.create(1, () => new MainNetContainer())
     await testing.container.start()
     // call rpc
     const { chain } = await testing.container.getMiningInfo()
@@ -45,7 +45,7 @@ describe('create a single test container using testwrapper', () => {
   })
 
   it('should be able to create testnet container', async () => {
-    testing = testingWrapper.create(1, index => new TestNetContainer()) as Testing
+    testing = testingWrapper.create(1, () => new TestNetContainer())
     await testing.container.start()
     // call rpc
     const { chain } = await testing.container.getMiningInfo()
@@ -101,7 +101,7 @@ describe('create multiple test container using testwrapper', () => {
     expect(blockHashAlice).toStrictEqual(blockHashBob)
 
     // create a non masternode RegTestTesting
-    const nonMasternodeTesting = testingWrapper.create(1, index => new RegTestContainer()) as Testing
+    const nonMasternodeTesting = testingWrapper.create(1, () => new RegTestContainer())
     await nonMasternodeTesting.container.start()
 
     // add to group
@@ -118,7 +118,7 @@ describe('create multiple test container using testwrapper', () => {
   it('should be able to create individual container of masternode and regtest and create a group from it', async () => {
     const masternodeTesting = testingWrapper.create()
     await masternodeTesting.container.start()
-    const nonmasternodeTesting = testingWrapper.create(1, (index) => new RegTestContainer()) as Testing
+    const nonmasternodeTesting = testingWrapper.create(1, () => new RegTestContainer())
     await nonmasternodeTesting.container.start()
 
     const tGroup = testingWrapper.group([masternodeTesting, nonmasternodeTesting])

--- a/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
+++ b/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
@@ -61,6 +61,15 @@ describe('create a single test container using testwrapper', () => {
     // eslint-disable-next-line @typescript-eslint/dot-notation
     expect(softforks['fortcanninghill'].height).toStrictEqual(11)
   })
+
+  it('should create 1 testing instance even if 0 is passed in as a param', async () => {
+    testing = testingWrapper.create(0, () => new RegTestContainer())
+    await testing.container.start()
+
+    // call rpc
+    const blockHeight = await testing.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(0)
+  })
 })
 
 describe('create multiple test container using testwrapper', () => {

--- a/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
+++ b/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
@@ -121,11 +121,8 @@ describe('create multiple test container using testwrapper', () => {
     const nonmasternodeTesting = testingWrapper.create(1, (index) => new RegTestContainer()) as Testing
     await nonmasternodeTesting.container.start()
 
-    const tGroup = testingWrapper.group()
+    const tGroup = testingWrapper.group([masternodeTesting, nonmasternodeTesting])
     await tGroup.start()
-
-    await tGroup.addTesting(masternodeTesting)
-    await tGroup.addTesting(nonmasternodeTesting)
 
     await masternodeTesting.container.generate(1)
     await tGroup.waitForSync()

--- a/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
+++ b/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
@@ -2,7 +2,6 @@ import { Testing } from '@defichain/jellyfish-testing'
 import { MainNetContainer, RegTestContainer, StartFlags, TestNetContainer } from '@defichain/testcontainers'
 import { TestingWrapper } from '../src/testingwrapper'
 
-const testingWrapper = new TestingWrapper()
 describe('create a single test container using testwrapper', () => {
   let testing: Testing
 
@@ -11,7 +10,7 @@ describe('create a single test container using testwrapper', () => {
   })
 
   it('should be able to create and call single regtest masternoderegtest container', async () => {
-    testing = testingWrapper.create()
+    testing = TestingWrapper.create()
     await testing.container.start()
 
     // call rpc
@@ -23,7 +22,7 @@ describe('create a single test container using testwrapper', () => {
   })
 
   it('should be able to create regtest non masternode container', async () => {
-    testing = testingWrapper.create(1, () => new RegTestContainer())
+    testing = TestingWrapper.create(1, () => new RegTestContainer())
     await testing.container.start()
 
     // call rpc
@@ -37,7 +36,7 @@ describe('create a single test container using testwrapper', () => {
   })
 
   it('should be able to create mainnet container', async () => {
-    testing = testingWrapper.create(1, () => new MainNetContainer())
+    testing = TestingWrapper.create(1, () => new MainNetContainer())
     await testing.container.start()
     // call rpc
     const { chain } = await testing.container.getMiningInfo()
@@ -45,7 +44,7 @@ describe('create a single test container using testwrapper', () => {
   })
 
   it('should be able to create testnet container', async () => {
-    testing = testingWrapper.create(1, () => new TestNetContainer())
+    testing = TestingWrapper.create(1, () => new TestNetContainer())
     await testing.container.start()
     // call rpc
     const { chain } = await testing.container.getMiningInfo()
@@ -53,7 +52,7 @@ describe('create a single test container using testwrapper', () => {
   })
 
   it('should be able to override start option', async () => {
-    testing = testingWrapper.create()
+    testing = TestingWrapper.create()
     const startFlags: StartFlags[] = [{ name: 'fortcanninghillheight', value: 11 }]
     await testing.container.start({ startFlags })
 
@@ -63,7 +62,7 @@ describe('create a single test container using testwrapper', () => {
   })
 
   it('should create 1 testing instance even if 0 is passed in as a param', async () => {
-    testing = testingWrapper.create(0, () => new RegTestContainer())
+    testing = TestingWrapper.create(0, () => new RegTestContainer())
     await testing.container.start()
 
     // call rpc
@@ -74,7 +73,7 @@ describe('create a single test container using testwrapper', () => {
 
 describe('create multiple test container using testwrapper', () => {
   it('should create a masternode group and test sync block and able to add and sync non masternode container', async () => {
-    const tGroup = testingWrapper.create(2)
+    const tGroup = TestingWrapper.create(2)
     await tGroup.start()
 
     const alice = tGroup.get(0)
@@ -110,7 +109,7 @@ describe('create multiple test container using testwrapper', () => {
     expect(blockHashAlice).toStrictEqual(blockHashBob)
 
     // create a non masternode RegTestTesting
-    const nonMasternodeTesting = testingWrapper.create(1, () => new RegTestContainer())
+    const nonMasternodeTesting = TestingWrapper.create(1, () => new RegTestContainer())
     await nonMasternodeTesting.container.start()
 
     // add to group
@@ -125,12 +124,12 @@ describe('create multiple test container using testwrapper', () => {
   })
 
   it('should be able to create individual container of masternode and regtest and create a group from it', async () => {
-    const masternodeTesting = testingWrapper.create()
+    const masternodeTesting = TestingWrapper.create()
     await masternodeTesting.container.start()
-    const nonmasternodeTesting = testingWrapper.create(1, () => new RegTestContainer())
+    const nonmasternodeTesting = TestingWrapper.create(1, () => new RegTestContainer())
     await nonmasternodeTesting.container.start()
 
-    const tGroup = testingWrapper.group([masternodeTesting, nonmasternodeTesting])
+    const tGroup = TestingWrapper.group([masternodeTesting, nonmasternodeTesting])
     await tGroup.start()
 
     await masternodeTesting.container.generate(1)

--- a/packages/jellyfish-testing/src/testing.ts
+++ b/packages/jellyfish-testing/src/testing.ts
@@ -89,7 +89,7 @@ export class TestingGroup {
     n: number,
     init?: (index: number) => DeFiDContainer
   ): TestingGroup {
-    const containers: MasterNodeRegTestContainer[] = []
+    const containers: DeFiDContainer[] = []
     const testings: Testing[] = []
 
     if (init === undefined) {
@@ -97,10 +97,10 @@ export class TestingGroup {
     }
 
     for (let i = 0; i < n; i += 1) {
-      const container = init(i) as MasterNodeRegTestContainer
+      const container = init(i)
       containers.push(container)
 
-      const testing = Testing.create(container)
+      const testing = Testing.createBase(container)
       testings.push(testing)
     }
 

--- a/packages/jellyfish-testing/src/testing.ts
+++ b/packages/jellyfish-testing/src/testing.ts
@@ -10,28 +10,27 @@ import { ContainerGroup, DeFiDContainer, MasterNodeRegTestContainer, StartOption
 import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 
-export class Testing<Container extends DeFiDContainer = DeFiDContainer> {
-  public readonly fixture: TestingFixture
-  public readonly icxorderbook: TestingICX
-
-  public readonly token!: Container extends MasterNodeRegTestContainer ? TestingToken : undefined
-  public readonly poolpair!: Container extends MasterNodeRegTestContainer ? TestingPoolPair : undefined
-  public readonly rawtx!: Container extends MasterNodeRegTestContainer ? TestingRawTx : undefined
-  public readonly misc!: Container extends MasterNodeRegTestContainer ? TestingMisc : undefined
+export class Testing {
+  public readonly container: MasterNodeRegTestContainer
+  public readonly fixture = new TestingFixture(this)
+  public readonly token!: TestingToken
+  public readonly poolpair!: TestingPoolPair
+  public readonly rawtx!: TestingRawTx
+  public readonly icxorderbook = new TestingICX(this)
+  public readonly misc!: TestingMisc
 
   private readonly addresses: Record<string, string> = {}
 
   private constructor (
-    public readonly container: Container,
+    public readonly con: DeFiDContainer,
     public readonly rpc: TestingJsonRpcClient
   ) {
-    this.fixture = new TestingFixture(this)
-    this.icxorderbook = new TestingICX(this)
-    if (container instanceof MasterNodeRegTestContainer) {
-      this.token = new TestingToken(container, this.rpc) as any
-      this.poolpair = new TestingPoolPair(container, this.rpc) as any
-      this.rawtx = new TestingRawTx(container, this.rpc) as any
-      this.misc = new TestingMisc(container, this.rpc) as any
+    this.container = this.con as MasterNodeRegTestContainer
+    if (con instanceof MasterNodeRegTestContainer) {
+      this.token = new TestingToken(this.container, this.rpc)
+      this.poolpair = new TestingPoolPair(this.container, this.rpc)
+      this.rawtx = new TestingRawTx(this.container, this.rpc)
+      this.misc = new TestingMisc(this.container, this.rpc)
     }
   }
 
@@ -63,11 +62,11 @@ export class Testing<Container extends DeFiDContainer = DeFiDContainer> {
     return addresses
   }
 
-  static create<Container extends DeFiDContainer> (container: Container): Testing<Container> {
+  static create (container: MasterNodeRegTestContainer): Testing {
     return this.createBase(container)
   }
 
-  static createBase<Container extends DeFiDContainer> (container: Container = new DeFiDContainer('regtest') as Container): Testing<Container> {
+  static createBase (container = new DeFiDContainer('regtest')): Testing {
     const rpc = new TestingJsonRpcClient(container)
     return new Testing(container, rpc)
   }

--- a/packages/jellyfish-testing/src/testing.ts
+++ b/packages/jellyfish-testing/src/testing.ts
@@ -10,27 +10,28 @@ import { ContainerGroup, DeFiDContainer, MasterNodeRegTestContainer, StartOption
 import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 
-export class Testing {
-  public readonly container: MasterNodeRegTestContainer
-  public readonly fixture = new TestingFixture(this)
-  public readonly token!: TestingToken
-  public readonly poolpair!: TestingPoolPair
-  public readonly rawtx!: TestingRawTx
-  public readonly icxorderbook = new TestingICX(this)
-  public readonly misc!: TestingMisc
+export class Testing<Container extends DeFiDContainer = DeFiDContainer> {
+  public readonly fixture: TestingFixture
+  public readonly icxorderbook: TestingICX
+
+  public readonly token!: Container extends MasterNodeRegTestContainer ? TestingToken : undefined
+  public readonly poolpair!: Container extends MasterNodeRegTestContainer ? TestingPoolPair : undefined
+  public readonly rawtx!: Container extends MasterNodeRegTestContainer ? TestingRawTx : undefined
+  public readonly misc!: Container extends MasterNodeRegTestContainer ? TestingMisc : undefined
 
   private readonly addresses: Record<string, string> = {}
 
   private constructor (
-    public readonly con: DeFiDContainer,
+    public readonly container: Container,
     public readonly rpc: TestingJsonRpcClient
   ) {
-    this.container = this.con as MasterNodeRegTestContainer
-    if (con instanceof MasterNodeRegTestContainer) {
-      this.token = new TestingToken(this.container, this.rpc)
-      this.poolpair = new TestingPoolPair(this.container, this.rpc)
-      this.rawtx = new TestingRawTx(this.container, this.rpc)
-      this.misc = new TestingMisc(this.container, this.rpc)
+    this.fixture = new TestingFixture(this)
+    this.icxorderbook = new TestingICX(this)
+    if (container instanceof MasterNodeRegTestContainer) {
+      this.token = new TestingToken(container, this.rpc) as any
+      this.poolpair = new TestingPoolPair(container, this.rpc) as any
+      this.rawtx = new TestingRawTx(container, this.rpc) as any
+      this.misc = new TestingMisc(container, this.rpc) as any
     }
   }
 
@@ -62,11 +63,11 @@ export class Testing {
     return addresses
   }
 
-  static create (container: MasterNodeRegTestContainer): Testing {
+  static create<Container extends DeFiDContainer> (container: Container): Testing<Container> {
     return this.createBase(container)
   }
 
-  static createBase (container = new DeFiDContainer('regtest')): Testing {
+  static createBase<Container extends DeFiDContainer> (container: Container = new DeFiDContainer('regtest') as Container): Testing<Container> {
     const rpc = new TestingJsonRpcClient(container)
     return new Testing(container, rpc)
   }

--- a/packages/jellyfish-testing/src/testing.ts
+++ b/packages/jellyfish-testing/src/testing.ts
@@ -11,26 +11,26 @@ import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 
 export class Testing {
-  public readonly container: MasterNodeRegTestContainer
   public readonly fixture = new TestingFixture(this)
-  public readonly token: TestingToken
-  public readonly poolpair: TestingPoolPair
-  public readonly rawtx: TestingRawTx
-  public readonly icxorderbook: TestingICX
-  public readonly misc: TestingMisc
+  public readonly token!: TestingToken
+  public readonly poolpair!: TestingPoolPair
+  public readonly rawtx!: TestingRawTx
+  public readonly icxorderbook = new TestingICX(this)
+  public readonly misc!: TestingMisc
 
   private readonly addresses: Record<string, string> = {}
 
   private constructor (
-    public readonly con: DeFiDContainer,
+    public readonly container: DeFiDContainer,
     public readonly rpc: TestingJsonRpcClient
   ) {
-    this.container = con as MasterNodeRegTestContainer
-    this.token = new TestingToken(this.container, this.rpc)
-    this.poolpair = new TestingPoolPair(this.container, this.rpc)
-    this.rawtx = new TestingRawTx(this.container, this.rpc)
-    this.icxorderbook = new TestingICX(this)
-    this.misc = new TestingMisc(this.container, this.rpc)
+    if (container instanceof MasterNodeRegTestContainer) {
+      const con = this.container as MasterNodeRegTestContainer
+      this.token = new TestingToken(con, this.rpc)
+      this.poolpair = new TestingPoolPair(con, this.rpc)
+      this.rawtx = new TestingRawTx(con, this.rpc)
+      this.misc = new TestingMisc(con, this.rpc)
+    }
   }
 
   async generate (n: number): Promise<void> {

--- a/packages/jellyfish-testing/src/testing.ts
+++ b/packages/jellyfish-testing/src/testing.ts
@@ -12,11 +12,11 @@ import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 
 export class Testing {
   public readonly container: MasterNodeRegTestContainer
-  public readonly fixture = new TestingFixture(this)
+  public readonly fixture!: TestingFixture
   public readonly token!: TestingToken
   public readonly poolpair!: TestingPoolPair
   public readonly rawtx!: TestingRawTx
-  public readonly icxorderbook = new TestingICX(this)
+  public readonly icxorderbook!: TestingICX
   public readonly misc!: TestingMisc
 
   private readonly addresses: Record<string, string> = {}
@@ -27,9 +27,11 @@ export class Testing {
   ) {
     this.container = this.con as MasterNodeRegTestContainer
     if (con instanceof MasterNodeRegTestContainer) {
+      this.fixture = new TestingFixture(this)
       this.token = new TestingToken(this.container, this.rpc)
       this.poolpair = new TestingPoolPair(this.container, this.rpc)
       this.rawtx = new TestingRawTx(this.container, this.rpc)
+      this.icxorderbook = new TestingICX(this)
       this.misc = new TestingMisc(this.container, this.rpc)
     }
   }

--- a/packages/jellyfish-testing/src/testing.ts
+++ b/packages/jellyfish-testing/src/testing.ts
@@ -11,7 +11,7 @@ import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 
 export class Testing {
-  public readonly container!: MasterNodeRegTestContainer
+  public readonly container: MasterNodeRegTestContainer
   public readonly fixture = new TestingFixture(this)
   public readonly token!: TestingToken
   public readonly poolpair!: TestingPoolPair
@@ -25,8 +25,8 @@ export class Testing {
     public readonly con: DeFiDContainer,
     public readonly rpc: TestingJsonRpcClient
   ) {
+    this.container = this.con as MasterNodeRegTestContainer
     if (con instanceof MasterNodeRegTestContainer) {
-      this.container = this.con as MasterNodeRegTestContainer
       this.token = new TestingToken(this.container, this.rpc)
       this.poolpair = new TestingPoolPair(this.container, this.rpc)
       this.rawtx = new TestingRawTx(this.container, this.rpc)

--- a/packages/jellyfish-testing/src/testing.ts
+++ b/packages/jellyfish-testing/src/testing.ts
@@ -11,6 +11,7 @@ import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 
 export class Testing {
+  public readonly container!: MasterNodeRegTestContainer
   public readonly fixture = new TestingFixture(this)
   public readonly token!: TestingToken
   public readonly poolpair!: TestingPoolPair
@@ -21,15 +22,15 @@ export class Testing {
   private readonly addresses: Record<string, string> = {}
 
   private constructor (
-    public readonly container: DeFiDContainer,
+    public readonly con: DeFiDContainer,
     public readonly rpc: TestingJsonRpcClient
   ) {
-    if (container instanceof MasterNodeRegTestContainer) {
-      const con = this.container as MasterNodeRegTestContainer
-      this.token = new TestingToken(con, this.rpc)
-      this.poolpair = new TestingPoolPair(con, this.rpc)
-      this.rawtx = new TestingRawTx(con, this.rpc)
-      this.misc = new TestingMisc(con, this.rpc)
+    if (con instanceof MasterNodeRegTestContainer) {
+      this.container = this.con as MasterNodeRegTestContainer
+      this.token = new TestingToken(this.container, this.rpc)
+      this.poolpair = new TestingPoolPair(this.container, this.rpc)
+      this.rawtx = new TestingRawTx(this.container, this.rpc)
+      this.misc = new TestingMisc(this.container, this.rpc)
     }
   }
 

--- a/packages/jellyfish-testing/src/testingwrapper.ts
+++ b/packages/jellyfish-testing/src/testingwrapper.ts
@@ -6,7 +6,7 @@ type InitDeFiContainerFn = (index: number) => DeFiDContainer
 function defaultInitDeFiContainer (index: number): DeFiDContainer {
   return new MasterNodeRegTestContainer(RegTestFoundationKeys[index])
 }
-export class TestingWrapper {
+export const TestingWrapper = new (class TestingWrapperFactory {
   create (): Testing
   create (n: 0 | 1): Testing
   create (n: number): TestingGroup
@@ -31,4 +31,4 @@ export class TestingWrapper {
     const group = new ContainerGroup(containers)
     return new TestingGroup(group, testings)
   }
-}
+})()

--- a/packages/jellyfish-testing/src/testingwrapper.ts
+++ b/packages/jellyfish-testing/src/testingwrapper.ts
@@ -19,10 +19,14 @@ export class TestingWrapper {
     return TestingGroup.create(n, init)
   }
 
-  group (): TestingGroup {
+  group (testings: Testing[]): TestingGroup {
     const containers: MasterNodeRegTestContainer[] = []
+
+    testings.forEach(testing => {
+      containers.push(testing.container)
+    })
+
     const group = new ContainerGroup(containers)
-    const testings: Testing[] = []
     return new TestingGroup(group, testings)
   }
 }

--- a/packages/jellyfish-testing/src/testingwrapper.ts
+++ b/packages/jellyfish-testing/src/testingwrapper.ts
@@ -8,10 +8,10 @@ function defaultInitDeFiContainer (index: number): DeFiDContainer {
 }
 export class TestingWrapper {
   create (): Testing
-  create (n: 1): Testing
+  create (n: 0 | 1): Testing
   create (n: number): TestingGroup
-  create (n: 1, init: InitDeFiContainerFn): Testing
-  create (n: number, init: InitDeFiContainerFn): Testing | TestingGroup
+  create (n: 0 | 1, init: InitDeFiContainerFn): Testing
+  create (n: number, init: InitDeFiContainerFn): TestingGroup
 
   create (n?: number, init: InitDeFiContainerFn = defaultInitDeFiContainer): Testing | TestingGroup {
     if (n === undefined || n <= 1) {
@@ -22,7 +22,7 @@ export class TestingWrapper {
   }
 
   group (testings: Testing[]): TestingGroup {
-    const containers: MasterNodeRegTestContainer[] = []
+    const containers: DeFiDContainer[] = []
 
     testings.forEach(testing => {
       containers.push(testing.container)

--- a/packages/jellyfish-testing/src/testingwrapper.ts
+++ b/packages/jellyfish-testing/src/testingwrapper.ts
@@ -2,16 +2,18 @@ import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
 import { ContainerGroup, DeFiDContainer, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { Testing, TestingGroup } from '.'
 
+type InitDeFiContainerFn = (index: number) => DeFiDContainer
+function defaultInitDeFiContainer (index: number): DeFiDContainer {
+  return new MasterNodeRegTestContainer(RegTestFoundationKeys[index])
+}
 export class TestingWrapper {
   create (): Testing
+  create (n: 1): Testing
   create (n: number): TestingGroup
-  create (n: number, init: (index: number) => DeFiDContainer): Testing | TestingGroup
+  create (n: 1, init: InitDeFiContainerFn): Testing
+  create (n: number, init: InitDeFiContainerFn): Testing | TestingGroup
 
-  create (n?: number, init?: (index: number) => DeFiDContainer): Testing | TestingGroup {
-    if (init === undefined) {
-      init = (index: number) => new MasterNodeRegTestContainer(RegTestFoundationKeys[index])
-    }
-
+  create (n?: number, init: InitDeFiContainerFn = defaultInitDeFiContainer): Testing | TestingGroup {
     if (n === undefined || n <= 1) {
       return Testing.createBase(init(0))
     }

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -122,6 +122,12 @@ export class DeFiDContainer extends DockerContainer {
     return await this.getPort('8554/tcp')
   }
 
+  async generate (n: number): Promise<void> {}
+
+  async getNewAddress (label: string = '', addressType: 'legacy' | 'p2sh-segwit' | 'bech32' | string = 'bech32'): Promise<string> {
+    return await this.call('getnewaddress', [label, addressType])
+  }
+
   /**
    * Get host machine url used for defid rpc calls with auth
    * TODO(fuxingloh): not a great design when network config changed, the url and ports get refresh

--- a/packages/testcontainers/src/containers/RegTestContainer/ContainerGroup.ts
+++ b/packages/testcontainers/src/containers/RegTestContainer/ContainerGroup.ts
@@ -1,15 +1,14 @@
 import Dockerode, { DockerOptions, Network } from 'dockerode'
 import { waitForCondition } from '../../utils'
 import { MasterNodeRegTestContainer } from './Masternode'
-import { RegTestContainer } from './index'
-import { StartOptions } from '../DeFiDContainer'
+import { DeFiDContainer, StartOptions } from '../DeFiDContainer'
 
 export class ContainerGroup {
   protected readonly docker: Dockerode
   protected network?: Network
 
   public constructor (
-    protected readonly containers: RegTestContainer[] = [],
+    protected readonly containers: DeFiDContainer[] = [],
     protected readonly name = `testcontainers-${Math.floor(Math.random() * 10000000)}`,
     options?: DockerOptions
   ) {
@@ -69,7 +68,7 @@ export class ContainerGroup {
   /**
    * @param {DeFiDContainer} container to add into container group with addnode
    */
-  async add (container: RegTestContainer): Promise<void> {
+  async add (container: DeFiDContainer): Promise<void> {
     await this.requireNetwork().connect({ Container: container.id })
 
     for (const each of this.containers) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
create a new layer of abstraction with the goal of being able to create a test /testGroup instance in a standardised manner.
creating a new layer seems to introduce the least amount of changes to existing use cases

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #637
Fixes #965 

#### Additional comments?:
Using the wrapper class
- should be able to create a single testing instance regardless of container
- should be able to create a new group and add new testing instance