### PR TITLE
chore(package.json): add subpath export for typescript

### DIFF
--- a/packages/jellyfish-api-core/package.json
+++ b/packages/jellyfish-api-core/package.json
@@ -18,6 +18,10 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./category/*": "./dist/category/*.js"
+  },
   "scripts": {
     "build": "tsc -b ./tsconfig.build.json"
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Experiment with subpath exports for `jellyfish-api-core`, new in typescript 4.5, this allows imports of category rpc without using declaring `@defichain/jellyfish-api-core/dist/*` -> `@defichain/jellyfish-api-core/*`.
