### PR TITLE
chore(whale-api-client): revert to original whale wrappers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26842,7 +26842,6 @@
       "dependencies": {
         "@defichain/jellyfish-api-core": "^0.0.0",
         "@defichain/jellyfish-api-jsonrpc": "^0.0.0",
-        "@defichain/ocean-api-client": "^0.0.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.5",
         "url-search-params-polyfill": "8.1.1"
@@ -28812,7 +28811,6 @@
       "requires": {
         "@defichain/jellyfish-api-core": "^0.0.0",
         "@defichain/jellyfish-api-jsonrpc": "^0.0.0",
-        "@defichain/ocean-api-client": "^0.0.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.5",
         "url-search-params-polyfill": "8.1.1"
@@ -37254,7 +37252,6 @@
           "requires": {
             "@defichain/jellyfish-api-core": "^0.0.0",
             "@defichain/jellyfish-api-jsonrpc": "^0.0.0",
-            "@defichain/ocean-api-client": "^0.0.0",
             "abort-controller": "^3.0.0",
             "cross-fetch": "^3.1.5",
             "url-search-params-polyfill": "8.1.1"

--- a/packages/whale-api-client/__tests__/WhaleApiClient.test.ts
+++ b/packages/whale-api-client/__tests__/WhaleApiClient.test.ts
@@ -8,7 +8,7 @@ const client = new WhaleApiClient({
 
 it('should requestData via GET', async () => {
   nock('http://whale-api-test.internal')
-    .get('/v0/whale/foo')
+    .get('/v0.0/whale/foo')
     .reply(200, function () {
       return {
         data: {
@@ -25,7 +25,7 @@ it('should requestData via GET', async () => {
 
 it('should requestData via POST', async () => {
   nock('http://whale-api-test.internal')
-    .post('/v0/whale/bar')
+    .post('/v0.0/whale/bar')
     .reply(200, function (_, body: object) {
       return {
         data: body

--- a/packages/whale-api-client/package.json
+++ b/packages/whale-api-client/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@defichain/jellyfish-api-core": "^0.0.0",
     "@defichain/jellyfish-api-jsonrpc": "^0.0.0",
-    "@defichain/ocean-api-client": "^0.0.0",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.5",
     "url-search-params-polyfill": "8.1.1"

--- a/packages/whale-api-client/src/Version.ts
+++ b/packages/whale-api-client/src/Version.ts
@@ -1,2 +1,2 @@
 /* eslint-disable import/no-default-export */
-export const version = 'v0'
+export const version = 'v0.0'

--- a/packages/whale-api-client/src/WhaleApiClient.ts
+++ b/packages/whale-api-client/src/WhaleApiClient.ts
@@ -1,4 +1,3 @@
-import { OceanApiClient } from '@defichain/ocean-api-client'
 import 'url-search-params-polyfill'
 import { version } from './Version'
 import { Address } from './api/Address'
@@ -14,6 +13,8 @@ import { Stats } from './api/Stats'
 import { Rawtx } from './api/RawTx'
 import { Fee } from './api/Fee'
 import { Loan } from './api/Loan'
+import { ApiPagedResponse, WhaleApiResponse } from './WhaleApiResponse'
+import { raiseIfError, WhaleApiException, WhaleClientException, WhaleClientTimeoutException } from './errors'
 
 /**
  * WhaleApiClient Options
@@ -39,7 +40,27 @@ export interface WhaleApiClientOptions {
   network?: 'mainnet' | 'testnet' | 'regtest' | string
 }
 
-export class WhaleApiClient extends OceanApiClient {
+/**
+ * WhaleApiClient default options
+ */
+const DEFAULT_OPTIONS: WhaleApiClientOptions = {
+  url: 'https://ocean.defichain.com',
+  timeout: 60000,
+  version: version,
+  network: 'mainnet'
+}
+
+/**
+ * Supported REST Method for DeFi Whale
+ */
+export type Method = 'POST' | 'GET'
+
+export interface ResponseAsString {
+  status: number
+  body: string
+}
+
+export class WhaleApiClient {
   public readonly rpc = new Rpc(this)
   public readonly address = new Address(this)
   public readonly poolpairs = new PoolPairs(this)
@@ -54,12 +75,129 @@ export class WhaleApiClient extends OceanApiClient {
   public readonly fee = new Fee(this)
   public readonly loan = new Loan(this)
 
-  constructor (options: WhaleApiClientOptions) {
-    super({
-      url: options.url,
-      timeout: options.timeout ?? 60000,
-      version: options.version ?? version,
-      network: options.network ?? 'mainnet'
-    })
+  constructor (
+    protected readonly options: WhaleApiClientOptions
+  ) {
+    this.options = { ...DEFAULT_OPTIONS, ...options }
+    this.options.url = this.options.url.replace(/\/$/, '')
+  }
+
+  /**
+   * @param {ApiPagedResponse} response from the previous request for pagination chaining
+   */
+  async paginate<T> (response: ApiPagedResponse<T>): Promise<ApiPagedResponse<T>> {
+    const token = response.nextToken
+    if (token === undefined) {
+      return new ApiPagedResponse({ data: [] }, response.method, response.endpoint)
+    }
+
+    const [path, query] = response.endpoint.split('?')
+    if (query === undefined) {
+      throw new WhaleClientException('endpoint does not contain query params for pagination')
+    }
+
+    const params = new URLSearchParams(query)
+    params.set('next', token.toString())
+    const endpoint = `${path}?${params.toString()}`
+
+    const apiResponse = await this.requestAsApiResponse<T[]>(response.method, endpoint)
+    return new ApiPagedResponse<T>(apiResponse, response.method, endpoint)
+  }
+
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {number} [size] of the list
+   * @param {string} [next] token for pagination
+   * @return {ApiPagedResponse} data list in the JSON response body for pagination query
+   * @see {paginate(ApiPagedResponse)} for pagination query chaining
+   */
+  async requestList<T> (method: Method, path: string, size: number, next?: string): Promise<ApiPagedResponse<T>> {
+    const params = new URLSearchParams()
+    params.set('size', size.toString())
+
+    if (next !== undefined) {
+      params.set('next', next)
+    }
+
+    const endpoint = `${path}?${params.toString()}`
+    const response = await this.requestAsApiResponse<T[]>(method, endpoint)
+    return new ApiPagedResponse<T>(response, method, endpoint)
+  }
+
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {any} [object] JSON to send in request
+   * @return {T} data object in the JSON response body
+   */
+  async requestData<T> (method: Method, path: string, object?: any): Promise<T> {
+    const response = await this.requestAsApiResponse<T>(method, path, object)
+    return response.data
+  }
+
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {object} [object] JSON to send in request
+   * @return {WhaleApiResponse} parsed structured JSON response
+   */
+  async requestAsApiResponse<T> (method: Method, path: string, object?: any): Promise<WhaleApiResponse<T>> {
+    const json = object !== undefined ? JSON.stringify(object) : undefined
+    const raw = await this.requestAsString(method, path, json)
+    const response: WhaleApiResponse<T> = JSON.parse(raw.body)
+    raiseIfError(response)
+    return response
+  }
+
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {object} [body] in string in request
+   * @return {ResponseAsString} as JSON string (RawResponse)
+   */
+  async requestAsString (method: Method, path: string, body?: string): Promise<ResponseAsString> {
+    const { url: urlString, version, network, timeout } = this.options
+    const url = `${urlString}/${version as string}/${network as string}/${path}`
+
+    const controller = new AbortController()
+    const id = setTimeout(() => controller.abort(), timeout)
+
+    try {
+      const response = await _fetch(method, url, controller, body)
+      clearTimeout(id)
+      return response
+    } catch (err) {
+      if ((err as WhaleApiException).type === 'aborted') {
+        /* eslint-disable @typescript-eslint/no-non-null-assertion */
+        throw new WhaleClientTimeoutException(timeout!)
+      }
+
+      throw err
+    }
+  }
+}
+
+/**
+ * Generic method for making http requests
+ *
+ * @param {Method} method for the endpoint
+ * @param {string} url to fetch
+ * @param {AbortController} controller for aborting request
+ * @param {string} body of the request
+ * @returns {Promise<ResponseAsString>}
+ */
+async function _fetch (method: Method, url: string, controller: AbortController, body?: string): Promise<ResponseAsString> {
+  const response = await fetch(url, {
+    method: method,
+    headers: method !== 'GET' ? { 'Content-Type': 'application/json' } : {},
+    body: body,
+    cache: 'no-cache',
+    signal: controller.signal
+  })
+
+  return {
+    status: response.status,
+    body: await response.text()
   }
 }

--- a/packages/whale-api-client/src/WhaleApiClient.ts
+++ b/packages/whale-api-client/src/WhaleApiClient.ts
@@ -1,4 +1,6 @@
 import 'url-search-params-polyfill'
+import AbortController from 'abort-controller'
+import fetch from 'cross-fetch'
 import { version } from './Version'
 import { Address } from './api/Address'
 import { PoolPairs } from './api/PoolPairs'

--- a/packages/whale-api-client/src/WhaleApiResponse.ts
+++ b/packages/whale-api-client/src/WhaleApiResponse.ts
@@ -1,0 +1,97 @@
+import { WhaleApiError } from './errors'
+import { Method } from './WhaleApiClient'
+
+export interface WhaleApiResponse<T> {
+  data: T
+  page?: ApiPage
+  error?: WhaleApiError
+}
+
+export interface ApiPage {
+  /**
+   * The next token for the next slice in the greater list.
+   * For simplicity, next token must a string or be encoded as a string.
+   * If the next token is in other formats such as bytes or number,
+   * it must be parsed by the controller.
+   */
+  next?: string
+}
+
+/**
+ * ApiPagedResponse class facilitate the ability to pagination query chaining.
+ * It extends the Array class and can be accessed like an array, `res[0]`, `res.length`.
+ *
+ * After accessing all the items in the Array, you can use the same ApiPagedResponse
+ * to query the next set of items. Hence allowing you query pagination chaining until you
+ * exhaustive all items in the list.
+ *
+ * @example
+ *   let response: ApiPagedResponse = await client.address.listToken(...)
+ *   for (const item of response) {
+ *     console.log(item)
+ *   }
+ *
+ *   // To query next set of items:
+ *   let response = await client.pagination(response)
+ *   for (const item of response) {
+ *     console.log(item)
+ *   }
+ */
+export class ApiPagedResponse<T> extends Array<T> {
+  private readonly _paginate: {
+    page?: ApiPage
+    method: Method
+    endpoint: string
+  }
+
+  /**
+   * @param {WhaleApiResponse} response that holds the data array and next token
+   * @param {Method} method of the REST endpoint
+   * @param {string} endpoint to paginate query
+   */
+  constructor (response: WhaleApiResponse<T[]>, method: Method, endpoint: string) {
+    super(...response.data)
+    this._paginate = {
+      page: response.page,
+      method: method,
+      endpoint: endpoint
+    }
+  }
+
+  /**
+   * Built-in methods such as map, filter creates a new array for functional programming.
+   * It does that with the constructor found in the static Symbol.species class property.
+   * This needs to be overridden as ApiPagedResponse constructor has a different signature.
+   */
+  static get [Symbol.species] (): ArrayConstructor {
+    return Array
+  }
+
+  /**
+   * @return {string} endpoint to paginate query
+   */
+  get endpoint (): string {
+    return this._paginate.endpoint
+  }
+
+  /**
+   * @return {Method} method of the REST endpoint
+   */
+  get method (): Method {
+    return this._paginate.method
+  }
+
+  /**
+   * @return {boolean} whether there a next set of items to paginate
+   */
+  get hasNext (): boolean {
+    return this.nextToken !== undefined
+  }
+
+  /**
+   * @return {string} next token
+   */
+  get nextToken (): string | undefined {
+    return this._paginate.page?.next
+  }
+}

--- a/packages/whale-api-client/src/api/Address.ts
+++ b/packages/whale-api-client/src/api/Address.ts
@@ -1,5 +1,5 @@
-import { ApiPagedResponse } from '@defichain/ocean-api-client'
 import { WhaleApiClient } from '../WhaleApiClient'
+import { ApiPagedResponse } from '../WhaleApiResponse'
 import { LoanVaultActive, LoanVaultLiquidated } from './Loan'
 
 /**

--- a/packages/whale-api-client/src/api/Blocks.ts
+++ b/packages/whale-api-client/src/api/Blocks.ts
@@ -1,5 +1,5 @@
-import { ApiPagedResponse } from '@defichain/ocean-api-client'
 import { WhaleApiClient } from '../WhaleApiClient'
+import { ApiPagedResponse } from '../WhaleApiResponse'
 import { Transaction } from './Transactions'
 
 export class Blocks {

--- a/packages/whale-api-client/src/api/Loan.ts
+++ b/packages/whale-api-client/src/api/Loan.ts
@@ -1,7 +1,7 @@
 import { WhaleApiClient } from '../WhaleApiClient'
+import { ApiPagedResponse } from '../WhaleApiResponse'
 import { TokenData } from './Tokens'
 import { ActivePrice } from './Prices'
-import { ApiPagedResponse } from '@defichain/ocean-api-client'
 
 export class Loan {
   constructor (private readonly client: WhaleApiClient) {

--- a/packages/whale-api-client/src/api/MasterNodes.ts
+++ b/packages/whale-api-client/src/api/MasterNodes.ts
@@ -1,5 +1,5 @@
-import { ApiPagedResponse } from '@defichain/ocean-api-client'
 import { WhaleApiClient } from '../WhaleApiClient'
+import { ApiPagedResponse } from '../WhaleApiResponse'
 
 /**
  * DeFi whale endpoint for masternode related services.

--- a/packages/whale-api-client/src/api/Oracles.ts
+++ b/packages/whale-api-client/src/api/Oracles.ts
@@ -1,5 +1,5 @@
-import { ApiPagedResponse } from '@defichain/ocean-api-client'
 import { WhaleApiClient } from '../WhaleApiClient'
+import { ApiPagedResponse } from '../WhaleApiResponse'
 
 /**
  * DeFi whale endpoint for oracle related services.

--- a/packages/whale-api-client/src/api/PoolPairs.ts
+++ b/packages/whale-api-client/src/api/PoolPairs.ts
@@ -1,5 +1,5 @@
-import { ApiPagedResponse } from '@defichain/ocean-api-client'
 import { WhaleApiClient } from '../WhaleApiClient'
+import { ApiPagedResponse } from '../WhaleApiResponse'
 
 /**
  * DeFi whale endpoint for poolpair related services.
@@ -93,6 +93,14 @@ export class PoolPairs {
    */
   async getAllPaths (fromTokenId: string, toTokenId: string): Promise<SwapPathsResult> {
     return await this.client.requestData('GET', `poolpairs/paths/from/${fromTokenId}/to/${toTokenId}`)
+  }
+
+  /**
+   * Get all dex prices denominated in a given token
+   * @param {string} [denomination='dUSD'] denomination
+   */
+  async listDexPrices (denomination: string): Promise<DexPricesResult> {
+    return await this.client.requestData('GET', `poolpairs/dexprices?denomination=${denomination}`)
   }
 }
 
@@ -229,7 +237,7 @@ export interface BestSwapPathResult {
   fromToken: TokenIdentifier
   toToken: TokenIdentifier
   bestPath: SwapPathPoolPair[]
-  estimatedReturn: string
+  estimatedReturn: string // BigNumber
 }
 
 export interface SwapPathsResult {
@@ -253,4 +261,16 @@ export interface TokenIdentifier {
   id: string
   symbol: string
   displaySymbol: string
+}
+
+export interface DexPricesResult {
+  denomination: TokenIdentifier
+  dexPrices: {
+    [symbol: string]: DexPrice
+  }
+}
+
+export interface DexPrice {
+  token: TokenIdentifier
+  denominationPrice: string // BigNumber
 }

--- a/packages/whale-api-client/src/api/Prices.ts
+++ b/packages/whale-api-client/src/api/Prices.ts
@@ -1,5 +1,5 @@
-import { ApiPagedResponse } from '@defichain/ocean-api-client'
 import { WhaleApiClient } from '../WhaleApiClient'
+import { ApiPagedResponse } from '../WhaleApiResponse'
 import { OraclePriceFeed } from './Oracles'
 
 /**

--- a/packages/whale-api-client/src/api/RawTx.ts
+++ b/packages/whale-api-client/src/api/RawTx.ts
@@ -1,12 +1,10 @@
-import { RawTx } from '@defichain/ocean-api-client'
 import { WhaleApiClient } from '../WhaleApiClient'
 
 /**
  * DeFi whale endpoint for rawtx related services.
  */
-export class Rawtx extends RawTx {
+export class Rawtx {
   constructor (private readonly client: WhaleApiClient) {
-    super(client)
   }
 
   /**

--- a/packages/whale-api-client/src/api/Rpc.ts
+++ b/packages/whale-api-client/src/api/Rpc.ts
@@ -1,6 +1,7 @@
 import { JellyfishJSON, Precision, PrecisionPath } from '@defichain/jellyfish-api-core'
-import { ApiException, ApiResponse } from '@defichain/ocean-api-client'
+import { raiseIfError } from '../errors'
 import { WhaleApiClient } from '../WhaleApiClient'
+import { WhaleApiResponse } from '../WhaleApiResponse'
 
 /**
  * @deprecated since 0.22.x, please use WhaleRpcClient directly
@@ -20,8 +21,8 @@ export class Rpc {
   async call<T> (method: string, params: any[], precision: Precision | PrecisionPath): Promise<T> {
     const body = JellyfishJSON.stringify({ params: params })
     const responseRaw = await this.client.requestAsString('POST', `rpc/${method}`, body)
-    const response: ApiResponse<T> = JellyfishJSON.parse(responseRaw.body, precision)
-    ApiException.raiseIfError(response)
+    const response: WhaleApiResponse<T> = JellyfishJSON.parse(responseRaw.body, precision)
+    raiseIfError(response)
     return response.data
   }
 }

--- a/packages/whale-api-client/src/api/Tokens.ts
+++ b/packages/whale-api-client/src/api/Tokens.ts
@@ -1,5 +1,5 @@
-import { ApiPagedResponse } from '@defichain/ocean-api-client'
 import { WhaleApiClient } from '../WhaleApiClient'
+import { ApiPagedResponse } from '../WhaleApiResponse'
 
 export class Tokens {
   constructor (private readonly client: WhaleApiClient) {

--- a/packages/whale-api-client/src/api/Transactions.ts
+++ b/packages/whale-api-client/src/api/Transactions.ts
@@ -1,5 +1,5 @@
-import { ApiPagedResponse } from '@defichain/ocean-api-client'
 import { WhaleApiClient } from '../WhaleApiClient'
+import { ApiPagedResponse } from '../WhaleApiResponse'
 
 export class Transactions {
   constructor (private readonly client: WhaleApiClient) {

--- a/packages/whale-api-client/src/errors/WhaleApiException.ts
+++ b/packages/whale-api-client/src/errors/WhaleApiException.ts
@@ -1,0 +1,64 @@
+export enum WhaleApiErrorType {
+  ValidationError = 'ValidationError',
+  BadRequest = 'BadRequest',
+  NotFound = 'NotFound',
+  Conflict = 'Conflict',
+  Forbidden = 'Forbidden',
+  Unauthorized = 'Unauthorized',
+  BadGateway = 'BadGateway',
+  TimeoutError = 'TimeoutError',
+  UnknownError = 'UnknownError',
+}
+
+export interface WhaleApiError {
+  code: number
+  type: WhaleApiErrorType
+  at: number
+  message?: string
+  url?: string
+}
+
+/**
+ * Serialized exception from DeFi Whale
+ */
+export class WhaleApiException extends Error {
+  constructor (readonly error: WhaleApiError) {
+    super(`${error.code} - ${error.type} ${WhaleApiException.url(error)}${WhaleApiException.message(error)}`)
+  }
+
+  /**
+   * @return {number} error code
+   */
+  get code (): number {
+    return this.error.code
+  }
+
+  /**
+   * @return {string} error type
+   */
+  get type (): string {
+    return this.error.type
+  }
+
+  /**
+   * @return {number} time that error occurred at
+   */
+  get at (): number {
+    return this.error.at
+  }
+
+  /**
+   * @return {string} url that threw this endpoint
+   */
+  get url (): string | undefined {
+    return this.error.url
+  }
+
+  static url ({ url }: WhaleApiError): string {
+    return url !== undefined && url !== null ? `(${url})` : ''
+  }
+
+  static message ({ message }: WhaleApiError): string {
+    return message !== undefined && message !== null ? `: ${message}` : ''
+  }
+}

--- a/packages/whale-api-client/src/errors/WhaleApiValidationException.ts
+++ b/packages/whale-api-client/src/errors/WhaleApiValidationException.ts
@@ -1,0 +1,24 @@
+import { WhaleApiException } from './WhaleApiException'
+
+/**
+ * Each property that failed constraint
+ */
+export interface ApiValidationProperty {
+  property: string
+  value?: any
+  constraints?: string[]
+  properties?: ApiValidationProperty[]
+}
+
+/**
+ * Rich constraints validation error coming from DeFi Whale API.
+ */
+export class WhaleApiValidationException extends WhaleApiException {
+  /**
+   * @return {ApiValidationProperty[]} that failed constraints validation
+   */
+  get properties (): ApiValidationProperty[] {
+    const error = this.error as any
+    return error.validation.properties
+  }
+}

--- a/packages/whale-api-client/src/errors/WhaleClientTimeoutException.ts
+++ b/packages/whale-api-client/src/errors/WhaleClientTimeoutException.ts
@@ -1,0 +1,14 @@
+/**
+ * Local client exception, due to local reason.
+ */
+export class WhaleClientException extends Error {
+}
+
+/**
+ * Whale client timeout locally.
+ */
+export class WhaleClientTimeoutException extends WhaleClientException {
+  constructor (public readonly timeout: number) {
+    super(`request aborted due to timeout of ${timeout} ms`)
+  }
+}

--- a/packages/whale-api-client/src/errors/index.ts
+++ b/packages/whale-api-client/src/errors/index.ts
@@ -1,0 +1,24 @@
+import { WhaleApiErrorType, WhaleApiException } from './WhaleApiException'
+import { WhaleApiValidationException } from './WhaleApiValidationException'
+import { WhaleApiResponse } from '../WhaleApiResponse'
+
+export * from './WhaleApiException'
+export * from './WhaleApiValidationException'
+export * from './WhaleClientTimeoutException'
+
+/**
+ * @param {WhaleApiResponse} response to check and raise error if any
+ * @throws {WhaleApiException} raised error
+ */
+export function raiseIfError (response: WhaleApiResponse<any>): void {
+  const error = response.error
+  if (error === undefined) {
+    return
+  }
+
+  if (error.code === 422 && error.type === WhaleApiErrorType.ValidationError) {
+    throw new WhaleApiValidationException(error)
+  }
+
+  throw new WhaleApiException(error)
+}

--- a/packages/whale-api-client/src/index.ts
+++ b/packages/whale-api-client/src/index.ts
@@ -1,4 +1,4 @@
-export * from '@defichain/ocean-api-client'
+export * from './errors'
 
 export * as rpc from './api/Rpc'
 export * as address from './api/Address'
@@ -15,4 +15,5 @@ export * as fee from './api/Fee'
 export * as loan from './api/Loan'
 
 export * from './WhaleApiClient'
+export * from './WhaleApiResponse'
 export * from './WhaleRpcClient'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Reverts some initial decisions during migration to adhere to the correct expectations of the original whale api client. This is mainly because of breaking expectations in tests compared to the original version.

Any further refactoring needs to be accompanied through a more complete onset of changes to every whale layer going forwards.

This is however a rather small revert simply adding back in what was removed during previous migration.

#### Additional comments?:

This is a precursor PR for whale api unit test migration:

 - https://github.com/DeFiCh/jellyfish/pull/1250

Original migration PR:

 - https://github.com/DeFiCh/jellyfish/pull/1166

This PR carries over changes made to whale-api-client in whale:

 - https://github.com/DeFiCh/whale/commit/46698bfcf814219af673e709bc817bcc345cbf07#diff-0e10f6cd3807333a55b6653be4aca13ef10ce9ae90b88a542084ef13d234012b