### PR TITLE
refactor(jellyfish-api-core): use precise typing for `AccountHistory`

### DIFF
--- a/apps/whale/src/module.api/address.controller.e2e.ts
+++ b/apps/whale/src/module.api/address.controller.e2e.ts
@@ -8,6 +8,7 @@ import { RpcApiError } from '@defichain/jellyfish-api-core'
 import { Testing } from '@defichain/jellyfish-testing'
 import { ForbiddenException } from '@nestjs/common'
 import BigNumber from 'bignumber.js'
+import { AddressHistory } from 'packages/whale-api-client/src/api/Address'
 
 const container = new MasterNodeRegTestContainer()
 let app: NestFastifyApplication
@@ -186,21 +187,21 @@ describe('listAccountHistory', () => {
     expect(first.data[1]).toStrictEqual(full.data[1])
     expect(first.data[2]).toStrictEqual(full.data[2])
 
-    const firstLast = first.data[first.data.length - 1]
+    const firstLast: AddressHistory = first.data[first.data.length - 1]
     const secondToken = `${firstLast.txid}-${firstLast.type}-${firstLast.block.height}`
     const second = await controller.listAccountHistory(colAddr, { size: 3, next: secondToken })
     expect(second.data[0]).toStrictEqual(full.data[3])
     expect(second.data[1]).toStrictEqual(full.data[4])
     expect(second.data[2]).toStrictEqual(full.data[5])
 
-    const secondLast = second.data[second.data.length - 1]
+    const secondLast: AddressHistory = second.data[second.data.length - 1]
     const thirdToken = `${secondLast.txid}-${secondLast.type}-${secondLast.block.height}`
     const third = await controller.listAccountHistory(colAddr, { size: 3, next: thirdToken })
     expect(third.data[0]).toStrictEqual(full.data[6])
     expect(third.data[1]).toStrictEqual(full.data[7])
     expect(third.data[2]).toStrictEqual(full.data[8])
 
-    const thirdLast = third.data[third.data.length - 1]
+    const thirdLast: AddressHistory = third.data[third.data.length - 1]
     const forthToken = `${thirdLast.txid}-${thirdLast.type}-${thirdLast.block.height}`
     const forth = await controller.listAccountHistory(colAddr, { size: 3, next: forthToken })
     expect(forth.data[0]).toStrictEqual(full.data[9])

--- a/apps/whale/src/module.api/address.controller.ts
+++ b/apps/whale/src/module.api/address.controller.ts
@@ -16,7 +16,7 @@ import { toBuffer } from '@defichain/jellyfish-transaction/dist/script/_buffer'
 import { LoanVaultActive, LoanVaultLiquidated } from '@defichain/whale-api-client/dist/api/Loan'
 import { LoanVaultService } from '../module.api/loan.vault.service'
 import { parseDisplaySymbol } from '../module.api/token.controller'
-import { AccountHistory } from '@defichain/jellyfish-api-core/dist/category/account'
+import { AccountHistoryWithTxn } from '@defichain/jellyfish-api-core/dist/category/account'
 
 @Controller('/address/:address')
 export class AddressController {
@@ -45,12 +45,12 @@ export class AddressController {
 
     const limit = query.size > 200 ? 200 : query.size
     const next = query.next ?? undefined
-    let list: AccountHistory[]
+    let list: AccountHistoryWithTxn[]
 
     if (next !== undefined) {
       const [txid, txType, maxBlockHeight] = next.split('-')
 
-      const loop = async (maxBlockHeight: number, limit: number): Promise<AccountHistory[]> => {
+      const loop = async (maxBlockHeight: number, limit: number): Promise<AccountHistoryWithTxn[]> => {
         const list = await this.rpcClient.account.listAccountHistory(address, {
           limit: limit,
           maxBlockHeight: maxBlockHeight,
@@ -83,8 +83,8 @@ export class AddressController {
 
     const history = mapAddressHistory(list)
 
-    return ApiPagedResponse.of(history, query.size, item => {
-      return `${item.txid}-${item.type}-${item.block.height}`
+    return ApiPagedResponse.of(history, query.size, (item: AddressHistory) => {
+      return `${item.txid}-${item.type}-${item.block.height.toString()}`
     })
   }
 
@@ -195,7 +195,7 @@ function mapAddressToken (id: string, tokenInfo: TokenInfo, value: BigNumber): A
   }
 }
 
-function mapAddressHistory (list: AccountHistory[]): AddressHistory[] {
+function mapAddressHistory (list: AccountHistoryWithTxn[]): AddressHistory[] {
   return list.map(each => {
     return {
       owner: each.owner,

--- a/docs/node/CATEGORIES/08-account.md
+++ b/docs/node/CATEGORIES/08-account.md
@@ -181,6 +181,15 @@ Returns information about account history
 
 ```ts title="client.account.listAccountHistory()"
 interface account {
+  async listAccountHistory (): Promise<AccountHistory[]>;
+  async listAccountHistory (
+    owner: OwnerType | string,
+    options: Omit<AccountHistoryOptions, 'no_rewards'> & {no_rewards: false}
+  ): Promise<AccountHistory[]>;
+  async listAccountHistory (
+    owner: OwnerType | string,
+    options: Omit<AccountHistoryOptions, 'no_rewards'> & {no_rewards: true}
+  ): Promise<AccountHistoryWithTxn[]>;
   listAccountHistory (
     owner: OwnerType | string = OwnerType.MINE,
     options: AccountHistoryOptions = {
@@ -221,9 +230,14 @@ interface AccountHistory {
   blockHash: string
   blockTime: number
   type: string
+  txn?: number
+  txid?: string
+  amounts: string[]
+}
+
+export interface AccountHistoryWithTxn extends AccountHistory {
   txn: number
   txid: string
-  amounts: string[]
 }
 
 interface AccountHistoryOptions {

--- a/packages/jellyfish-api-core/__tests__/category/account/getAccountHistory.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/account/getAccountHistory.test.ts
@@ -36,8 +36,9 @@ describe('Account', () => {
     const accountHistories = await testing.rpc.account.listAccountHistory(hex)
 
     const referenceHistory = accountHistories[0]
+    expect(referenceHistory.txn).not.toBeUndefined() // assert here to ensure test works as expected
 
-    const history = await testing.rpc.account.getAccountHistory(hex, referenceHistory.blockHeight, referenceHistory.txn)
+    const history = await testing.rpc.account.getAccountHistory(hex, referenceHistory.blockHeight, referenceHistory.txn!)
     expect(history.owner).toStrictEqual(referenceHistory.owner)
     expect(history.blockHeight).toStrictEqual(referenceHistory.blockHeight)
     expect(history.txn).toStrictEqual(referenceHistory.txn)
@@ -54,8 +55,9 @@ describe('Account', () => {
     expect(accountHistories.length).toBeGreaterThan(0)
 
     const referenceHistory = accountHistories[0]
+    expect(referenceHistory.txn).not.toBeUndefined() // assert here to ensure test works as expected
 
-    const history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn)
+    const history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn!)
     expect(history.owner).toStrictEqual(referenceHistory.owner)
     expect(history.blockHeight).toStrictEqual(referenceHistory.blockHeight)
     expect(history.txn).toStrictEqual(referenceHistory.txn)
@@ -71,11 +73,12 @@ describe('Account', () => {
     expect(accountHistories.length).toBeGreaterThan(0)
 
     const referenceHistory = accountHistories[0]
+    expect(referenceHistory.txn).not.toBeUndefined() // assert here to ensure test works as expected
 
-    const history = await testing.rpc.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERwyvFg9K21j', referenceHistory.blockHeight, referenceHistory.txn)
+    const history = await testing.rpc.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERwyvFg9K21j', referenceHistory.blockHeight, referenceHistory.txn!)
     expect(history.owner).toBeUndefined()
 
-    const historyPromise = testing.rpc.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERw', referenceHistory.blockHeight, referenceHistory.txn - 1)
+    const historyPromise = testing.rpc.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERw', referenceHistory.blockHeight, referenceHistory.txn! - 1)
     await expect(historyPromise).rejects.toThrow(RpcApiError)
     await expect(historyPromise).rejects.toThrow('does not refer to any valid address')
   })
@@ -85,11 +88,12 @@ describe('Account', () => {
     expect(accountHistories.length).toBeGreaterThan(0)
 
     const referenceHistory = accountHistories[0]
+    expect(referenceHistory.txn).not.toBeUndefined() // assert here to ensure test works as expected
 
-    let history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight - 1, referenceHistory.txn)
+    let history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight - 1, referenceHistory.txn!)
     expect(history.owner).toBeUndefined()
 
-    history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, -1, referenceHistory.txn)
+    history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, -1, referenceHistory.txn!)
     expect(history.owner).toBeUndefined()
   })
 
@@ -98,8 +102,9 @@ describe('Account', () => {
     expect(accountHistories.length).toBeGreaterThan(0)
 
     const referenceHistory = accountHistories[0]
+    expect(referenceHistory.txn).not.toBeUndefined() // assert here to ensure test works as expected
 
-    let history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn - 1)
+    let history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn! - 1)
     expect(history.owner).toBeUndefined()
 
     history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, -1)

--- a/packages/jellyfish-api-core/src/category/account.ts
+++ b/packages/jellyfish-api-core/src/category/account.ts
@@ -278,6 +278,23 @@ export class Account {
     return await this.client.call('accounttoutxos', [from, payload, options.utxos], 'number')
   }
 
+  async listAccountHistory (): Promise<AccountHistory[]>;
+
+  async listAccountHistory (
+    owner: OwnerType | string,
+    options: Omit<AccountHistoryOptions, 'no_rewards'> & {no_rewards: false}
+  ): Promise<AccountHistoryWithTxn[]>;
+
+  async listAccountHistory (
+    owner: OwnerType | string,
+    options: Omit<AccountHistoryOptions, 'no_rewards'> & {no_rewards: true}
+  ): Promise<AccountHistoryWithTxn[]>;
+
+  async listAccountHistory (
+    owner: OwnerType | string,
+    options?: AccountHistoryOptions
+  ): Promise<AccountHistory[]>;
+
   /**
    * Returns information about account history
    *
@@ -297,7 +314,7 @@ export class Account {
     options: AccountHistoryOptions = {
       limit: 100
     }
-  ): Promise<AccountHistory[]> {
+  ): Promise<AccountHistory[] | AccountHistoryWithTxn[]> {
     return await this.client.call('listaccounthistory', [owner, options], 'number')
   }
 
@@ -441,6 +458,17 @@ export interface UTXO {
 }
 
 export interface AccountHistory {
+  owner: string
+  blockHeight: number
+  blockHash: string
+  blockTime: number
+  type: string
+  txn?: number
+  txid?: string
+  amounts: string[]
+}
+
+export interface AccountHistoryWithTxn extends AccountHistory {
   owner: string
   blockHeight: number
   blockHash: string

--- a/packages/jellyfish-api-core/src/category/account.ts
+++ b/packages/jellyfish-api-core/src/category/account.ts
@@ -469,14 +469,8 @@ export interface AccountHistory {
 }
 
 export interface AccountHistoryWithTxn extends AccountHistory {
-  owner: string
-  blockHeight: number
-  blockHash: string
-  blockTime: number
-  type: string
   txn: number
   txid: string
-  amounts: string[]
 }
 
 export interface AccountHistoryOptions {

--- a/packages/jellyfish-api-core/src/category/account.ts
+++ b/packages/jellyfish-api-core/src/category/account.ts
@@ -283,7 +283,7 @@ export class Account {
   async listAccountHistory (
     owner: OwnerType | string,
     options: Omit<AccountHistoryOptions, 'no_rewards'> & {no_rewards: false}
-  ): Promise<AccountHistoryWithTxn[]>;
+  ): Promise<AccountHistory[]>;
 
   async listAccountHistory (
     owner: OwnerType | string,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

This PR aims to provide more precise typing for `AccountHistory`, by utilizing function overriding and a more specific `AccountHistoryWithTxn` type for those with `no_rewards: true` options.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1303

#### Additional comments?:
