### PR TITLE
fix(status-api): Update to check status of first active tickers of the oracle

### DIFF
--- a/apps/status-api/README.md
+++ b/apps/status-api/README.md
@@ -24,10 +24,10 @@ To provide the status of the blockchain based on the block creation time interva
 To provide the status of each oracle given the address based on the last published time for any given token
 
 
-| Status             | Threshold Time   |
-|--------------------|------------------|
-| `operational`      | `<= 45 minutes`  |
-| `outage`           | `> 45 minutes`   |
+| Status             | Threshold Time  |
+|--------------------|-----------------|
+| `operational`      | `<= 60 minutes` |
+| `outage`           | `> 60 minutes`  |
 
  
 ### `/overall`

--- a/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
+++ b/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
@@ -42,6 +42,20 @@ describe('OracleStatusController - Status test', () => {
     })
     expect(res.statusCode).toStrictEqual(200)
   })
+
+  it('/oracles/<address> - should get outage no results are returned', async () => {
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).oracles, 'getPriceFeed')
+      .mockReturnValueOnce(getMockedOraclePriceFeedEmpty('df1qm7f2cx8vs9lqn8v43034nvp0fjsnvie93j'))
+
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: 'oracles/df1qm7f2cx8vs9lqn8v43034nvp0fjsnvie93j'
+    })
+    expect(res.json()).toStrictEqual({
+      status: 'outage'
+    })
+    expect(res.statusCode).toStrictEqual(200)
+  })
 })
 
 async function getMockedOraclePriceFeed (oracleAddress: string, minutesDiff: number): Promise<ApiPagedResponse<OraclePriceFeed>> {
@@ -65,6 +79,12 @@ async function getMockedOraclePriceFeed (oracleAddress: string, minutesDiff: num
       time: 0,
       amount: ''
     }]
+  }, 'GET', `oracles/${oracleAddress}/AAPL-USD/feed`)
+}
+
+async function getMockedOraclePriceFeedEmpty (oracleAddress: string): Promise<ApiPagedResponse<OraclePriceFeed>> {
+  return new ApiPagedResponse({
+    data: []
   }, 'GET', `oracles/${oracleAddress}/AAPL-USD/feed`)
 }
 

--- a/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
+++ b/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
@@ -43,7 +43,7 @@ describe('OracleStatusController - Status test', () => {
     expect(res.statusCode).toStrictEqual(200)
   })
 
-  it('/oracles/<address> - should get outage no results are returned', async () => {
+  it('/oracles/<address> - should get outage if no results are returned', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).oracles, 'getPriceFeed')
       .mockReturnValueOnce(getMockedOraclePriceFeedEmpty('df1qm7f2cx8vs9lqn8v43034nvp0fjsnvie93j'))
 

--- a/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
+++ b/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
@@ -15,7 +15,7 @@ afterAll(async () => {
 })
 
 describe('OracleStatusController - Status test', () => {
-  it('/oracles/<address> - should get operational as last published < 45 mins ago', async () => {
+  it('/oracles/<address> - should get operational as last published <= 60 mins ago', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).oracles, 'getPriceFeed')
       .mockReturnValueOnce(getMockedOraclePriceFeed('df1qm7f2cx8vs9lqn8v43034nvckz6dxxpqezfh6dw', 5))
 
@@ -29,9 +29,9 @@ describe('OracleStatusController - Status test', () => {
     expect(res.statusCode).toStrictEqual(200)
   })
 
-  it('/oracles/<address> - should get outage as last published >= 45 mins ago', async () => {
+  it('/oracles/<address> - should get outage as last published > 60 mins ago', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).oracles, 'getPriceFeed')
-      .mockReturnValueOnce(getMockedOraclePriceFeed('df1qcpp3entq53tdyklm5v0lnvqer4verr4puxchq4', 46))
+      .mockReturnValueOnce(getMockedOraclePriceFeed('df1qcpp3entq53tdyklm5v0lnvqer4verr4puxchq4', 62))
 
     const res = await apiTesting.app.inject({
       method: 'GET',

--- a/apps/status-api/src/controllers/OracleStatusController.ts
+++ b/apps/status-api/src/controllers/OracleStatusController.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Param } from '@nestjs/common'
 import { WhaleApiClient } from '@defichain/whale-api-client'
-import { OraclePriceFeed } from '@defichain/whale-api-client/dist/api/Oracles'
+import { Oracle } from '@defichain/whale-api-client/dist/api/Oracles'
 import { SemaphoreCache } from '../../../whale/src/module.api/cache/semaphore.cache'
 
 type OracleStatus = 'outage' | 'operational'
@@ -21,18 +21,30 @@ export class OracleStatusController {
    */
   @Get('/:address')
   async getOracleStatus (@Param('address') oracleAddress: string): Promise<{ status: OracleStatus }> {
-    const oraclePriceFeed: OraclePriceFeed = await this.cachedGet(`oracle-${oracleAddress}`, async () => {
+    return await this.cachedGet(`oracle-${oracleAddress}`, async () => {
       const oracle = await this.client.oracles.getOracleByAddress(oracleAddress)
-      return (await this.client.oracles.getPriceFeed(oracle.id, oracle.priceFeeds[0].token, oracle.priceFeeds[0].currency, 1))[0]
-    }, 5) // cache result for 5 seconds
+      return await this.getAlivePriceFeed(oracle)
+    }, 5) // cache status result for 5 seconds
+  }
 
-    const nowEpoch = Date.now()
-    const latestPublishedTime = oraclePriceFeed.block.medianTime * 1000
-    const timeDiff = nowEpoch - latestPublishedTime
+  private async getAlivePriceFeed (oracle: Oracle): Promise<{ status: OracleStatus }> {
+    const id = oracle.id
 
-    return {
-      status: timeDiff <= (45 * 60 * 1000) ? 'operational' : 'outage'
+    for (const priceFeed of oracle.priceFeeds) {
+      const token = priceFeed.token
+      const currency = priceFeed.currency
+      const oraclePriceFeed = await this.client.oracles.getPriceFeed(id, token, currency, 1)
+      if (oraclePriceFeed.length !== 0) { // check if ticker is not returning any data, else move on to the next ticker
+        const nowEpoch = Date.now()
+        const latestPublishedTime = oraclePriceFeed[0].block.medianTime * 1000
+        const timeDiff = nowEpoch - latestPublishedTime
+
+        if (timeDiff <= (45 * 60 * 1000)) { // check if ticker last published price within 45 min, else move on to next ticker
+          return { status: 'operational' }
+        }
+      }
     }
+    return { status: 'outage' } // return as outage if all tickers from this oracle does not fulfill above conditions
   }
 
   private async cachedGet<T> (field: string, fetch: () => Promise<T>, ttl: number): Promise<T> {

--- a/apps/status-api/src/controllers/OracleStatusController.ts
+++ b/apps/status-api/src/controllers/OracleStatusController.ts
@@ -34,15 +34,19 @@ export class OracleStatusController {
       const token = priceFeed.token
       const currency = priceFeed.currency
       const oraclePriceFeed = await this.client.oracles.getPriceFeed(id, token, currency, 1)
-      if (oraclePriceFeed.length !== 0) { // check if ticker is not returning any data, else move on to the next ticker
-        const nowEpoch = Date.now()
-        const latestPublishedTime = oraclePriceFeed[0].block.medianTime * 1000
-        const timeDiff = nowEpoch - latestPublishedTime
 
-        // check if ticker last published price within 60 min, else move on to next ticker
-        if (timeDiff <= (60 * 60 * 1000)) { // increasing to 60 min as there are occurrences where publishing txn did not go through (~3 times)
-          return { status: 'operational' }
-        }
+      // move on to the next ticker if oraclePriceFeed does not return any data
+      if (oraclePriceFeed.length === 0) {
+        continue
+      }
+
+      const nowEpoch = Date.now()
+      const latestPublishedTime = oraclePriceFeed[0].block.medianTime * 1000
+      const timeDiff = nowEpoch - latestPublishedTime
+
+      // check if ticker last published price within 60 min, else move on to next ticker
+      if (timeDiff <= (60 * 60 * 1000)) { // increasing to 60 min as there are occurrences where publishing txn did not go through (~3 times)
+        return { status: 'operational' }
       }
     }
     return { status: 'outage' } // return as outage if all tickers from this oracle does not fulfill above conditions

--- a/apps/status-api/src/controllers/OracleStatusController.ts
+++ b/apps/status-api/src/controllers/OracleStatusController.ts
@@ -39,7 +39,8 @@ export class OracleStatusController {
         const latestPublishedTime = oraclePriceFeed[0].block.medianTime * 1000
         const timeDiff = nowEpoch - latestPublishedTime
 
-        if (timeDiff <= (45 * 60 * 1000)) { // check if ticker last published price within 45 min, else move on to next ticker
+        // check if ticker last published price within 60 min, else move on to next ticker
+        if (timeDiff <= (60 * 60 * 1000)) { // increasing to 60 min as there are occurrences where publishing txn did not go through (~3 times)
           return { status: 'operational' }
         }
       }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Previously, the logic for checking status of the oracle takes the first ticker returned from whale. However, some of the tickers are dormant, which means no data or outdated data will be returned, resulting in inaccurate status.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
