### PR TITLE
fix(packages/jellyfish-transaction): Add another fixture and fix wrong letter for withdrawFromVault DFTX

### DIFF
--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_loans/WithdrawFromVault.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_loans/WithdrawFromVault.test.ts
@@ -25,7 +25,15 @@ it('should bi-directional buffer-object-buffer', () => {
         amount: '1@BTC'
       }
      */
-    '6a454466547853aec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed16001488d52b9b1dded932272e0c9bebb0dccdd46ecf990100e1f50500000000'
+    '6a454466547853aec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed16001488d52b9b1dded932272e0c9bebb0dccdd46ecf990100e1f50500000000',
+    /**
+     * WithdrawFromVault : {
+        vaultId: 'a9e685e0de7f3923bd578c03c5c207a0eb234f0ae3c420303f00792e3856651f',
+        to: 'bcrt1q4wpnc2l3h6zrpnm4unm8m4nvxstgtsvz44j8md',
+        amount: '1@BTC'
+      }
+     */
+    '6a4544665478531f6556382e79003f3020c4e30a4f23eba007c2c5038c57bd23397fdee085e6a9160014ab833c2bf1be8430cf75e4f67dd66c341685c1820200e1f50500000000'
   ]
 
   fixtures.forEach(hex => {

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_loans/WithdrawFromVault.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_loans/WithdrawFromVault.test.ts
@@ -17,7 +17,7 @@ it('should bi-directional buffer-object-buffer', () => {
         amount: '10000@DFI'
       }
      */
-    '6a454466547853aec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed16001488d52b9b1dded932272e0c9bebb0dccdd46ecf99000010a5d4e8000000',
+    '6a45446654784aaec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed16001488d52b9b1dded932272e0c9bebb0dccdd46ecf99000010a5d4e8000000',
     /**
      * WithdrawFromVault : {
         vaultId: 'ed59b0558f03d547819c1990bfbade53656170e2c311d9b8b418a6a74ae4c2ae',
@@ -25,7 +25,7 @@ it('should bi-directional buffer-object-buffer', () => {
         amount: '1@BTC'
       }
      */
-    '6a454466547853aec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed16001488d52b9b1dded932272e0c9bebb0dccdd46ecf990100e1f50500000000',
+    '6a45446654784aaec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed16001488d52b9b1dded932272e0c9bebb0dccdd46ecf990100e1f50500000000',
     /**
      * WithdrawFromVault : {
         vaultId: 'a9e685e0de7f3923bd578c03c5c207a0eb234f0ae3c420303f00792e3856651f',
@@ -33,7 +33,7 @@ it('should bi-directional buffer-object-buffer', () => {
         amount: '1@BTC'
       }
      */
-    '6a4544665478531f6556382e79003f3020c4e30a4f23eba007c2c5038c57bd23397fdee085e6a9160014ab833c2bf1be8430cf75e4f67dd66c341685c1820200e1f50500000000'
+    '6a45446654784a1f6556382e79003f3020c4e30a4f23eba007c2c5038c57bd23397fdee085e6a9160014ab833c2bf1be8430cf75e4f67dd66c341685c1820200e1f50500000000'
   ]
 
   fixtures.forEach(hex => {
@@ -42,11 +42,11 @@ it('should bi-directional buffer-object-buffer', () => {
     )
     const buffer = toBuffer(stack)
     expect(buffer.toString('hex')).toStrictEqual(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x53)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x4a)
   })
 })
 
-const header = '6a45446654784a' // OP_RETURN(0x6a) (length 69 = 0x45) CDfTx.SIGNATURE(0x44665478) CWithdrawFromVault.OP_CODE(0x4A)
+const header = '6a45446654784a' // OP_RETURN(0x6a) (length 69 = 0x45) CDfTx.SIGNATURE(0x44665478) CWithdrawFromVault.OP_CODE(0x4a)
 // WithdrawFromVault.vaultId[LE](0xaec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed)
 // WithdrawFromVault.to(0x16001488d52b9b1dded932272e0c9bebb0dccdd46ecf99)
 // WithdrawFromVault.amount(0x000019ef6d1f010000)

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_vault/WithdrawFromVault.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_vault/WithdrawFromVault.test.ts
@@ -17,7 +17,7 @@ it('should bi-directional buffer-object-buffer', () => {
         amount: '10000@DFI'
       }
      */
-    '6a454466547853aec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed16001488d52b9b1dded932272e0c9bebb0dccdd46ecf99000010a5d4e8000000',
+    '6a45446654784aaec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed16001488d52b9b1dded932272e0c9bebb0dccdd46ecf99000010a5d4e8000000',
     /**
      * WithdrawFromVault : {
         vaultId: 'ed59b0558f03d547819c1990bfbade53656170e2c311d9b8b418a6a74ae4c2ae',
@@ -25,7 +25,15 @@ it('should bi-directional buffer-object-buffer', () => {
         amount: '1@BTC'
       }
      */
-    '6a454466547853aec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed16001488d52b9b1dded932272e0c9bebb0dccdd46ecf990100e1f50500000000'
+    '6a45446654784aaec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed16001488d52b9b1dded932272e0c9bebb0dccdd46ecf990100e1f50500000000',
+    /**
+     * WithdrawFromVault : {
+        vaultId: 'a9e685e0de7f3923bd578c03c5c207a0eb234f0ae3c420303f00792e3856651f',
+        to: 'bcrt1q4wpnc2l3h6zrpnm4unm8m4nvxstgtsvz44j8md',
+        amount: '1@BTC'
+      }
+     */
+    '6a45446654784a1f6556382e79003f3020c4e30a4f23eba007c2c5038c57bd23397fdee085e6a9160014ab833c2bf1be8430cf75e4f67dd66c341685c1820200e1f50500000000'
   ]
 
   fixtures.forEach(hex => {
@@ -34,11 +42,11 @@ it('should bi-directional buffer-object-buffer', () => {
     )
     const buffer = toBuffer(stack)
     expect(buffer.toString('hex')).toStrictEqual(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x53)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x4a)
   })
 })
 
-const header = '6a45446654784a' // OP_RETURN(0x6a) (length 69 = 0x45) CDfTx.SIGNATURE(0x44665478) CWithdrawFromVault.OP_CODE(0x4A)
+const header = '6a45446654784a' // OP_RETURN(0x6a) (length 69 = 0x45) CDfTx.SIGNATURE(0x44665478) CWithdrawFromVault.OP_CODE(0x4a)
 // WithdrawFromVault.vaultId[LE](0xaec2e44aa7a618b4b8d911c3e270616553debabf90199c8147d5038f55b059ed)
 // WithdrawFromVault.to(0x16001488d52b9b1dded932272e0c9bebb0dccdd46ecf99)
 // WithdrawFromVault.amount(0x000019ef6d1f010000)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
There are only 2 fixtures for withdrawFromVault DFTX. Adding 1 more fixture as the minimum requirement is at least 3 fixtures.

Also, withdrawFromVault uses J.  The letter S (0x53) should be changed to J (0x4a).

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1398

#### Additional comments?:
