### PR TITLE
feat(jellyfish-api-core): add blockchain getMempoolDescendants RPC

### DIFF
--- a/docs/node/CATEGORIES/01-blockchain.md
+++ b/docs/node/CATEGORIES/01-blockchain.md
@@ -395,13 +395,12 @@ interface ChainTxStats {
 
 ## getMempoolDescendants
 
- Get all in-mempool descendants if txId is in mempool as string[] if verbose is false else as json object.
+Get all in-mempool descendants if txId is in mempool as string[] if verbose is false else as json object.
 
- ```ts title="client.blockchain.getMempoolDescendants()"
- interface blockchain {
-   getMempoolDescendants (txId: string, verbose: true): Promise<MempoolTx>
-   getMempoolDescendants (txId: string, verbose: false): Promise<string[]>
-   getMempoolDescendants (txId: string, verbose: boolean): Promise<MempoolTx | string[]>
- }
- ```
- 
+```ts title="client.blockchain.getMempoolDescendants()"
+interface blockchain {
+  getMempoolDescendants (txId: string, verbose: true): Promise<MempoolTx>
+  getMempoolDescendants (txId: string, verbose: false): Promise<string[]>
+  getMempoolDescendants (txId: string, verbose: boolean): Promise<MempoolTx | string[]>
+}
+```

--- a/docs/node/CATEGORIES/01-blockchain.md
+++ b/docs/node/CATEGORIES/01-blockchain.md
@@ -395,12 +395,43 @@ interface ChainTxStats {
 
 ## getMempoolDescendants
 
-Get all in-mempool descendants if txId is in mempool as string[] if verbose is false else as json object.
+Get all in-mempool descendants if txId is in mempool as string[] if verbose is false else as json object
 
 ```ts title="client.blockchain.getMempoolDescendants()"
 interface blockchain {
   getMempoolDescendants (txId: string, verbose: true): Promise<MempoolTx>
   getMempoolDescendants (txId: string, verbose: false): Promise<string[]>
   getMempoolDescendants (txId: string, verbose: boolean): Promise<MempoolTx | string[]>
+}
+
+interface MempoolTx {
+  [key: string]: {
+    vsize: BigNumber
+    /**
+     * @deprecated same as vsize. Only returned if defid is started with -deprecatedrpc=size
+     */
+    size: BigNumber
+    weight: BigNumber
+    fee: BigNumber
+    modifiedfee: BigNumber
+    time: BigNumber
+    height: BigNumber
+    descendantcount: BigNumber
+    descendantsize: BigNumber
+    descendantfees: BigNumber
+    ancestorcount: BigNumber
+    ancestorsize: BigNumber
+    ancestorfees: BigNumber
+    wtxid: string
+    fees: {
+      base: BigNumber
+      modified: BigNumber
+      ancestor: BigNumber
+      descendant: BigNumber
+    }
+    depends: string[]
+    spentby: string[]
+    'bip125-replaceable': boolean
+  }
 }
 ```

--- a/docs/node/CATEGORIES/01-blockchain.md
+++ b/docs/node/CATEGORIES/01-blockchain.md
@@ -392,3 +392,16 @@ interface ChainTxStats {
   txrate: number
 }
 ```
+
+## getMempoolDescendants
+
+ Get all in-mempool descendants if txId is in mempool as string[] if verbose is false else as json object.
+
+ ```ts title="client.blockchain.getMempoolDescendants()"
+ interface blockchain {
+   getMempoolDescendants (txId: string, verbose: true): Promise<MempoolTx>
+   getMempoolDescendants (txId: string, verbose: false): Promise<string[]>
+   getMempoolDescendants (txId: string, verbose: boolean): Promise<MempoolTx | string[]>
+ }
+ ```
+ 

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
@@ -24,41 +24,40 @@ describe('getMempoolDescendants', () => {
   })
 
   it('should return JSON object if verbose is true', async () => {
-    for (let i = 0; i < 3; i++) {
-      await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
-    }
-    const txId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
-    const mempoolEntry: MempoolTx = await testing.rpc.blockchain.getMempoolDescendants(txId, true)
-    const entryKey = Object.keys(mempoolEntry)[0]
+    const ancestorTxId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
     await waitForExpect(async () => {
-      expect(Object.keys(mempoolEntry).length).toBeGreaterThan(0)
-      expect(mempoolEntry[entryKey]).toStrictEqual({
-        fees: expect.any(Object),
-        vsize: expect.any(BigNumber),
-        weight: expect.any(BigNumber),
-        fee: expect.any(BigNumber),
-        modifiedfee: expect.any(BigNumber),
-        time: expect.any(BigNumber),
-        height: expect.any(BigNumber),
-        descendantcount: expect.any(BigNumber),
-        descendantsize: expect.any(BigNumber),
-        descendantfees: expect.any(BigNumber),
-        ancestorcount: expect.any(BigNumber),
-        ancestorsize: expect.any(BigNumber),
-        ancestorfees: expect.any(BigNumber),
-        wtxid: expect.any(String),
-        depends: expect.any(Array),
-        spentby: expect.any(Array),
-        'bip125-replaceable': expect.any(Boolean)
-      })
+      await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
+      const mempoolEntry: MempoolTx = await testing.rpc.blockchain.getMempoolDescendants(ancestorTxId, true)
+      expect(mempoolEntry.length).toBeGreaterThan(0)
     }, 10000)
+
+    const entryKey = Object.keys(mempoolEntry)[0]
+    expect(mempoolEntry[entryKey]).toStrictEqual({
+      fees: expect.any(Object),
+      vsize: expect.any(BigNumber),
+      weight: expect.any(BigNumber),
+      fee: expect.any(BigNumber),
+      modifiedfee: expect.any(BigNumber),
+      time: expect.any(BigNumber),
+      height: expect.any(BigNumber),
+      descendantcount: expect.any(BigNumber),
+      descendantsize: expect.any(BigNumber),
+      descendantfees: expect.any(BigNumber),
+      ancestorcount: expect.any(BigNumber),
+      ancestorsize: expect.any(BigNumber),
+      ancestorfees: expect.any(BigNumber),
+      wtxid: expect.any(String),
+      depends: expect.any(Array),
+      spentby: expect.any(Array),
+      'bip125-replaceable': expect.any(Boolean)
+    })
   })
 
   it('should return array of txids if verbose is false', async () => {
-    const txId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
+    const ancestorTxId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
     await waitForExpect(async () => {
       await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
-      const mempoolEntry: string[] = await testing.rpc.blockchain.getMempoolDescendants(txId, false)
+      const mempoolEntry: string[] = await testing.rpc.blockchain.getMempoolDescendants(ancestorTxId, false)
       expect(mempoolEntry.length).toBeGreaterThan(0)
     }, 10000)
   })
@@ -66,7 +65,8 @@ describe('getMempoolDescendants', () => {
   it('should return error if tx not in mempool', async () => {
     const txId = '9fb9c46b1d12dae8a4a35558f7ef4b047df3b444b1ead61d334e4f187f5f58b7'
     await waitForExpect(async () => {
-      await expect(testing.rpc.blockchain.getMempoolDescendants(txId, false)).rejects.toThrow('RpcApiError: \'Transaction not in mempool\', code: -5, method: getmempooldescendants')
+      await expect(testing.rpc.blockchain.getMempoolDescendants(txId, false)).rejects
+        .toThrow('RpcApiError: \'Transaction not in mempool\', code: -5, method: getmempooldescendants')
     }, 10000)
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
@@ -31,6 +31,7 @@ describe('getMempoolDescendants', () => {
       expect(mempoolEntry.length).toBeGreaterThan(0)
     }, 10000)
 
+    const mempoolEntry: MempoolTx = await testing.rpc.blockchain.getMempoolDescendants(ancestorTxId, true)
     const entryKey = Object.keys(mempoolEntry)[0]
     expect(mempoolEntry[entryKey]).toStrictEqual({
       fees: expect.any(Object),

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
@@ -1,0 +1,73 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import BigNumber from 'bignumber.js'
+import { MempoolTx } from '../../../src/category/blockchain'
+import waitForExpect from 'wait-for-expect'
+import { Testing } from '@defichain/jellyfish-testing'
+import { expectHexBufferToObject } from 'packages/jellyfish-transaction/__tests__/tx_composer'
+
+describe('getMempoolDescendants', () => {
+  const container = new MasterNodeRegTestContainer()
+  const testing = Testing.create(container)
+
+  beforeAll(async () => {
+    await testing.container.start()
+    await testing.container.waitForWalletCoinbaseMaturity()
+  })
+
+  afterAll(async () => {
+    await testing.container.stop()
+  })
+
+  it('should return no descendant ids for tx without descendants', async () => {
+    const txId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
+    const mempoolEntry: string[] = await testing.rpc.blockchain.getMempoolDescendants(txId, false)
+    expect(mempoolEntry.length).toStrictEqual(0)
+  })
+
+  it('should return JSON object if verbose is true', async () => {
+    for (let i = 0; i < 3; i++) {
+      await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
+    }
+    const txId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
+    const mempoolEntry: MempoolTx = await testing.rpc.blockchain.getMempoolDescendants(txId, true)
+    const entryKey = Object.keys(mempoolEntry)[0]
+    await waitForExpect(async () => {
+      expect(Object.keys(mempoolEntry).length).toBeGreaterThan(0)
+      expect(mempoolEntry[entryKey]).toStrictEqual({
+        fees: expect.any(Object),
+        vsize: expect.any(BigNumber),
+        weight: expect.any(BigNumber),
+        fee: expect.any(BigNumber),
+        modifiedfee: expect.any(BigNumber),
+        time: expect.any(BigNumber),
+        height: expect.any(BigNumber),
+        descendantcount: expect.any(BigNumber),
+        descendantsize: expect.any(BigNumber),
+        descendantfees: expect.any(BigNumber),
+        ancestorcount: expect.any(BigNumber),
+        ancestorsize: expect.any(BigNumber),
+        ancestorfees: expect.any(BigNumber),
+        wtxid: expect.any(String),
+        depends: expect.any(Array),
+        spentby: expect.any(Array),
+        'bip125-replaceable': expect.any(Boolean)
+      })
+    }, 10000)
+  })
+
+  it('should return array of txids if verbose is false', async () => {
+    const txId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
+    await waitForExpect(async () => {
+      await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
+      const mempoolEntry: string[] = await testing.rpc.blockchain.getMempoolDescendants(txId, false)
+      expect(mempoolEntry.length).toBeGreaterThan(0)
+    }, 10000)
+  })
+
+  it('should return error if tx not in mempool', async () => {
+    const txId = '9fb9c46b1d12dae8a4a35558f7ef4b047df3b444b1ead61d334e4f187f5f58b7'
+    await waitForExpect(async () => {
+      await expect(testing.rpc.blockchain.getMempoolDescendants(txId, false)).rejects.toThrow('RpcApiError: \'Transaction not in mempool\', code: -5, method: getmempooldescendants')
+    }, 10000)
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
@@ -3,7 +3,6 @@ import BigNumber from 'bignumber.js'
 import { MempoolTx } from '../../../src/category/blockchain'
 import waitForExpect from 'wait-for-expect'
 import { Testing } from '@defichain/jellyfish-testing'
-import { expectHexBufferToObject } from 'packages/jellyfish-transaction/__tests__/tx_composer'
 
 describe('getMempoolDescendants', () => {
   const container = new MasterNodeRegTestContainer()

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
@@ -28,7 +28,7 @@ describe('getMempoolDescendants', () => {
     await waitForExpect(async () => {
       await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
       const mempoolEntry: MempoolTx = await testing.rpc.blockchain.getMempoolDescendants(ancestorTxId, true)
-      expect(mempoolEntry.length).toBeGreaterThan(0)
+      expect(Object.keys(mempoolEntry).length).toBeGreaterThan(0)
     }, 10000)
 
     const mempoolEntry: MempoolTx = await testing.rpc.blockchain.getMempoolDescendants(ancestorTxId, true)
@@ -60,14 +60,14 @@ describe('getMempoolDescendants', () => {
       await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.0003)
       const mempoolEntry: string[] = await testing.rpc.blockchain.getMempoolDescendants(ancestorTxId, false)
       expect(mempoolEntry.length).toBeGreaterThan(0)
+      expect(mempoolEntry.values().next().value.toString().length).toStrictEqual(64)
     }, 10000)
   })
 
   it('should return error if tx not in mempool', async () => {
     const txId = '9fb9c46b1d12dae8a4a35558f7ef4b047df3b444b1ead61d334e4f187f5f58b7'
-    await waitForExpect(async () => {
-      await expect(testing.rpc.blockchain.getMempoolDescendants(txId, false)).rejects
-        .toThrow('RpcApiError: \'Transaction not in mempool\', code: -5, method: getmempooldescendants')
-    }, 10000)
+    const promise = testing.rpc.blockchain.getMempoolDescendants(txId, false)
+    await expect(promise).rejects
+      .toThrow('RpcApiError: \'Transaction not in mempool\', code: -5, method: getmempooldescendants')
   })
 })

--- a/packages/jellyfish-api-core/src/category/blockchain.ts
+++ b/packages/jellyfish-api-core/src/category/blockchain.ts
@@ -228,7 +228,8 @@ export class Blockchain {
 
   /**
    * Get all in-mempool descendants for the given transaction as string[]
-   * @param {string} txId the transaction id in mempool
+   *
+   * @param {string} txId the transaction id
    * @param {boolean} verbose false
    * @returns {Promise<string[]>}
    */
@@ -236,6 +237,7 @@ export class Blockchain {
 
   /**
    * Get all in-mempool descendants for the given transaction as MempoolTx object
+   *
    * @param {string} txId the transaction id
    * @param {boolean} verbose true
    * @returns {Promise<MempoolTx>}
@@ -243,8 +245,8 @@ export class Blockchain {
   getMempoolDescendants (txId: string, verbose: true): Promise<MempoolTx>
 
   /**
-   * Get all in-mempool descendants for the given transaction as JSON object
-   * if verbose is true else as string[]
+   * Get all in-mempool descendants if txId is in mempool as string[]
+   * if verbose is false else as json object
    *
    * @param {string} txId the transaction id
    * @param {boolean} verbose true for json object, false for array of transaction ids

--- a/packages/jellyfish-api-core/src/category/blockchain.ts
+++ b/packages/jellyfish-api-core/src/category/blockchain.ts
@@ -227,19 +227,19 @@ export class Blockchain {
   }
 
   /**
-  * Get all in-mempool descendants for the given transaction as string[]
-  * @param {string} txId the transaction id in mempool
-  * @param {boolean} verbose false
-  * @returns {Promise<string[]>}
-  */
+   * Get all in-mempool descendants for the given transaction as string[]
+   * @param {string} txId the transaction id in mempool
+   * @param {boolean} verbose false
+   * @returns {Promise<string[]>}
+   */
   getMempoolDescendants (txId: string, verbose: false): Promise<string[]>
 
   /**
-  * Get all in-mempool descendants for the given transaction as MempoolTx object
-  * @param {string} txId the transaction id
-  * @param {boolean} verbose true
-  * @returns {Promise<MempoolTx>}
-  */
+   * Get all in-mempool descendants for the given transaction as MempoolTx object
+   * @param {string} txId the transaction id
+   * @param {boolean} verbose true
+   * @returns {Promise<MempoolTx>}
+   */
   getMempoolDescendants (txId: string, verbose: true): Promise<MempoolTx>
 
   /**
@@ -250,7 +250,7 @@ export class Blockchain {
    * @param {boolean} verbose true for json object, false for array of transaction ids
    * @returns {Promise<string[] | MempoolTx>}
    */
-   async getMempoolDescendants (txId: string, verbose: boolean): Promise<string[] | MempoolTx> {
+  async getMempoolDescendants (txId: string, verbose: boolean): Promise<string[] | MempoolTx> {
     return await this.client.call('getmempooldescendants', [txId, verbose], 'bignumber')
   }
 }

--- a/packages/jellyfish-api-core/src/category/blockchain.ts
+++ b/packages/jellyfish-api-core/src/category/blockchain.ts
@@ -225,6 +225,34 @@ export class Blockchain {
   async getChainTxStats (nBlocks?: number, blockHash?: string): Promise<ChainTxStats> {
     return await this.client.call('getchaintxstats', [nBlocks, blockHash], 'number')
   }
+
+  /**
+  * Get all in-mempool descendants for the given transaction as string[]
+  * @param {string} txId the transaction id in mempool
+  * @param {boolean} verbose false
+  * @returns {Promise<string[]>}
+  */
+  getMempoolDescendants (txId: string, verbose: false): Promise<string[]>
+
+  /**
+  * Get all in-mempool descendants for the given transaction as MempoolTx object
+  * @param {string} txId the transaction id
+  * @param {boolean} verbose true
+  * @returns {Promise<MempoolTx>}
+  */
+  getMempoolDescendants (txId: string, verbose: true): Promise<MempoolTx>
+
+  /**
+   * Get all in-mempool descendants for the given transaction as JSON object
+   * if verbose is true else as string[]
+   *
+   * @param {string} txId the transaction id
+   * @param {boolean} verbose true for json object, false for array of transaction ids
+   * @returns {Promise<string[] | MempoolTx>}
+   */
+   async getMempoolDescendants (txId: string, verbose: boolean): Promise<string[] | MempoolTx> {
+    return await this.client.call('getmempooldescendants', [txId, verbose], 'bignumber')
+  }
 }
 
 /**


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR implements blockchain.getMempoolDescendants() from ain

#### Which issue(s) does this PR fixes?:
Part of #48

#### Additional comments?:
