### PR TITLE
fix(legacy_api): Updated v1 and v2 /listswaps regex to match tickers with a period

### DIFF
--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -107,7 +107,7 @@ it('/v1/listswaps', async () => {
   const v1JsonResponse = res.json()
   for (const [key, poolpair] of Object.entries(v1JsonResponse)) {
     // Verify all keys follow snake case
-    expect(key).toMatch(/^\w+_\w+$/)
+    expect(key).toMatch(/^\w+(?:\.\w+)?_\w+$/)
 
     // Verify each swap object's fields
     expect(poolpair).toStrictEqual({
@@ -155,7 +155,7 @@ it('/v2/listswaps', async () => {
   const v2JsonResponse = res.json()
   for (const [key, poolpair] of Object.entries(v2JsonResponse)) {
     // Verify all keys follow snake case
-    expect(key).toMatch(/^\w+_\w+$/)
+    expect(key).toMatch(/^\w+(?:\.\w+)?_\w+$/)
     // Verify each swap object's fields
     expect(poolpair).toStrictEqual({
       base_id: expect.any(String),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Updated v1 and v2 /listswaps regex to match tickers with a period