### PR TITLE
chore(whale): sync with whale packages

### DIFF
--- a/packages/whale-api-client/src/api/Address.ts
+++ b/packages/whale-api-client/src/api/Address.ts
@@ -10,6 +10,18 @@ export class Address {
   }
 
   /**
+   * Get account history
+   *
+   * @param {string} address to get account history
+   * @param {number} height block height of the account history
+   * @param {number} txno order of txn
+   * @return {Promise<AddressHistory | undefined>}
+   */
+  async getAccountHistory (address: string, height: number, txno: number): Promise<AddressHistory | undefined> {
+    return await this.client.requestData('GET', `address/${address}/history/${height}/${txno}`)
+  }
+
+  /**
    * List account history
    *
    * @param {string} address to list account history

--- a/packages/whale-api-client/src/api/PoolPairs.ts
+++ b/packages/whale-api-client/src/api/PoolPairs.ts
@@ -115,7 +115,12 @@ export interface PoolPairData {
     symbol: string
     displaySymbol: string
     reserve: string // BigNumber
-    blockCommission: string // BigNumber
+    blockCommission: string // BigNumber,
+    fee?: {
+      pct?: string // BigNumber
+      inPct?: string // BigNumber
+      outPct?: string // BigNumber
+    }
   }
   tokenB: {
     id: string
@@ -123,6 +128,11 @@ export interface PoolPairData {
     displaySymbol: string
     reserve: string // BigNumber
     blockCommission: string // BigNumber
+    fee?: {
+      pct?: string // BigNumber
+      inPct?: string // BigNumber
+      outPct?: string // BigNumber
+    }
   }
   priceRatio: {
     ab: string // BigNumber


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Simple package sync with latest changes to whale repository to push forwards migration efforts and bringing it over the finish line.

#### Additional comments?:

This brings jellyfish up to date with changes in client and wallet packages to:

 - https://github.com/JellyfishSDK/whale/commit/a93c495780bcbae1da38e8e642f0def493f3de96

Important note is that unit tests that depends on `src` in whale are not ported as part of the packages. Because of the migration being split into consolidated PRs the whale app has not been available to the packages during migration. Will also note that potentially we do not want to have packages being dependent on the project applications, so for application based testing we should keep them in the application scope.

I think we should be porting a refactored version of the unit tests into the packages, but should do so in a manner that does not induce a direct dependency of our application environment.

Here is a list of unit tests that needs to be ported:

 - https://github.com/JellyfishSDK/whale/tree/main/packages/whale-api-client/__tests__
