### PR TITLE
fix(whale-migration): fix issues caused by reverting initial whale-api-client refactoring

### DIFF
--- a/apps/status-api/src/modules/WhaleApiModule.ts
+++ b/apps/status-api/src/modules/WhaleApiModule.ts
@@ -46,7 +46,7 @@ export class WhaleApiProbeIndicator extends ProbeIndicator {
       useFactory: (configService: ConfigService): WhaleApiClient => {
         return new WhaleApiClient({
           version: 'v0',
-          network: configService.get<string>('network'),
+          network: configService.get<string>('network') ?? 'mainnet',
           url: 'https://ocean.defichain.com'
         })
       },

--- a/packages/rich-list-core/test/StubbedWhaleClient.ts
+++ b/packages/rich-list-core/test/StubbedWhaleClient.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@defichain/jellyfish-api-core'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
-import { ApiMethod, ResponseAsString, WhaleApiClient } from '@defichain/whale-api-client'
+import { Method, ResponseAsString, WhaleApiClient } from '@defichain/whale-api-client'
 
 /**
  * a Stubbed WhaleApiClient for test purpose.
@@ -13,7 +13,7 @@ export class StubbedWhaleApiClient extends WhaleApiClient {
     this.stubMethods()
   }
 
-  async requestAsString (method: ApiMethod, path: string, body?: string): Promise<ResponseAsString> {
+  async requestAsString (method: Method, path: string, body?: string): Promise<ResponseAsString> {
     // stub the api method thus test case logic should not reach this point
     throw new Error(`Endpoint "${method}/${path}" not stubbed for test`)
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Fixes lint and build failing due to imported 'Method' that wasn't updated during the whale-api-client refactoring reversion
- Fixes WhaleApiClient not enforcing default values, causing status-api test failure due

#### Which issue(s) does this PR fixes?:
Part of #977 
