### PR TITLE
chore(whale-api-client): Default whale api client to v0 and let url be optional

### DIFF
--- a/packages/whale-api-client/__tests__/WhaleApiClient.test.ts
+++ b/packages/whale-api-client/__tests__/WhaleApiClient.test.ts
@@ -3,7 +3,8 @@ import { WhaleApiClient } from '../src/WhaleApiClient'
 
 const client = new WhaleApiClient({
   url: 'http://whale-api-test.internal',
-  network: 'whale'
+  network: 'whale',
+  version: 'v0'
 })
 
 it('should requestData via GET', async () => {

--- a/packages/whale-api-client/__tests__/WhaleApiClient.test.ts
+++ b/packages/whale-api-client/__tests__/WhaleApiClient.test.ts
@@ -4,7 +4,7 @@ import { WhaleApiClient } from '../src/WhaleApiClient'
 const client = new WhaleApiClient({
   url: 'http://whale-api-test.internal',
   network: 'whale',
-  version: 'v0'
+  version: 'v0.0'
 })
 
 it('should requestData via GET', async () => {

--- a/packages/whale-api-client/__tests__/stub.client.ts
+++ b/packages/whale-api-client/__tests__/stub.client.ts
@@ -8,7 +8,7 @@ import AbortController from 'abort-controller'
  */
 export class StubWhaleApiClient extends WhaleApiClient {
   constructor (readonly service: StubService) {
-    super({ url: 'not required for stub service' })
+    super({})
   }
 
   async requestAsString (method: Method, path: string, body?: string): Promise<ResponseAsString> {

--- a/packages/whale-api-client/__tests__/stub.client.ts
+++ b/packages/whale-api-client/__tests__/stub.client.ts
@@ -16,10 +16,9 @@ export class StubWhaleApiClient extends WhaleApiClient {
       throw new Error('StubService is not yet started.')
     }
 
-    const version = this.options.version as string
     const res = await this.service.app.inject({
       method: method,
-      url: `/${version}/regtest/${path}`,
+      url: `/v0.0/regtest/${path}`,
       payload: body,
       headers: method !== 'GET' ? { 'Content-Type': 'application/json' } : {}
     })
@@ -43,7 +42,7 @@ export class StubWhaleRpcClient extends WhaleRpcClient {
 
     const res = await this.service.app.inject({
       method: 'POST',
-      url: '/v0/regtest/rpc',
+      url: '/v0.0/regtest/rpc',
       payload: body,
       headers: { 'Content-Type': 'application/json' }
     })

--- a/packages/whale-api-client/__tests__/stub.client.ts
+++ b/packages/whale-api-client/__tests__/stub.client.ts
@@ -1,6 +1,5 @@
 import { Method, ResponseAsString, WhaleApiClient, WhaleRpcClient } from '../src'
 import { StubService } from './stub.service'
-import { version } from '../src/Version'
 import AbortController from 'abort-controller'
 
 /**
@@ -44,7 +43,7 @@ export class StubWhaleRpcClient extends WhaleRpcClient {
 
     const res = await this.service.app.inject({
       method: 'POST',
-      url: `/${version as string}/regtest/rpc`,
+      url: '/v0/regtest/rpc',
       payload: body,
       headers: { 'Content-Type': 'application/json' }
     })

--- a/packages/whale-api-client/src/Version.ts
+++ b/packages/whale-api-client/src/Version.ts
@@ -1,1 +1,0 @@
-export const version = 'v0.0'

--- a/packages/whale-api-client/src/WhaleApiClient.ts
+++ b/packages/whale-api-client/src/WhaleApiClient.ts
@@ -80,6 +80,7 @@ export class WhaleApiClient {
     protected readonly options: WhaleApiClientOptions
   ) {
     this.options = { ...DEFAULT_OPTIONS, ...options }
+    this.options.url = this.options.url?.replace(/\/$/, '')
   }
 
   /**

--- a/packages/whale-api-client/src/WhaleApiClient.ts
+++ b/packages/whale-api-client/src/WhaleApiClient.ts
@@ -1,7 +1,6 @@
 import 'url-search-params-polyfill'
 import AbortController from 'abort-controller'
 import fetch from 'cross-fetch'
-import { version } from './Version'
 import { Address } from './api/Address'
 import { PoolPairs } from './api/PoolPairs'
 import { Rpc } from './api/Rpc'
@@ -22,7 +21,7 @@ import { raiseIfError, WhaleApiException, WhaleClientException, WhaleClientTimeo
  * WhaleApiClient Options
  */
 export interface WhaleApiClientOptions {
-  url: string
+  url?: string
 
   /**
    * Millis before request is aborted.
@@ -48,7 +47,7 @@ export interface WhaleApiClientOptions {
 const DEFAULT_OPTIONS: WhaleApiClientOptions = {
   url: 'https://ocean.defichain.com',
   timeout: 60000,
-  version: version,
+  version: 'v0',
   network: 'mainnet'
 }
 
@@ -81,7 +80,6 @@ export class WhaleApiClient {
     protected readonly options: WhaleApiClientOptions
   ) {
     this.options = { ...DEFAULT_OPTIONS, ...options }
-    this.options.url = this.options.url.replace(/\/$/, '')
   }
 
   /**
@@ -160,7 +158,7 @@ export class WhaleApiClient {
    */
   async requestAsString (method: Method, path: string, body?: string): Promise<ResponseAsString> {
     const { url: urlString, version, network, timeout } = this.options
-    const url = `${urlString}/${version as string}/${network as string}/${path}`
+    const url = `${urlString as string}/${version as string}/${network as string}/${path}`
 
     const controller = new AbortController()
     const id = setTimeout(() => controller.abort(), timeout)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Currently WhaleApiClient options version default to the current npm release version. I think to ensure forever backward compatibility for users, we should default to v0.

Duplicate of https://github.com/JellyfishSDK/whale/pull/980, changes raised here as part of migration

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/JellyfishSDK/whale/issues/979

#### Additional comments?:
