### PR TITLE
fix(status-api): Default network to mainnet for status-api controller module

### DIFF
--- a/apps/status-api/src/modules/ControllerModule.ts
+++ b/apps/status-api/src/modules/ControllerModule.ts
@@ -28,7 +28,7 @@ import { OverallStatusController } from '../controllers/OverallStatusController'
       useFactory: (configService: ConfigService): WhaleApiClient => {
         return new WhaleApiClient({
           version: 'v0',
-          network: configService.get<string>('network'),
+          network: configService.get<string>('network') ?? 'mainnet',
           url: 'https://ocean.defichain.com'
         })
       },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Default network to mainnet when it is undefined for status-api

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Application was not able to find ocean api causing the api calls to fail

#### Additional comments?:
