### PR TITLE
chore(apps/legacy-api): skip flaky tests

### DIFF
--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -250,6 +250,8 @@ it('/v1/listyieldfarming', async () => {
   })
 })
 
+// TODO(eli-lim): unskip tests when
+//   https://github.com/JellyfishSDK/whale/issues/981 is resolved
 describe('getsubgraphswaps', () => {
   it('/v1/getsubgraphswaps', async () => {
     const res = await apiTesting.app.inject({
@@ -295,7 +297,7 @@ describe('getsubgraphswaps', () => {
     expect(response.data.swaps.length).toStrictEqual(0)
   })
 
-  it('/v1/getsubgraphswaps?limit=101 - limited to 100', async () => {
+  it.skip('/v1/getsubgraphswaps?limit=101 - limited to 100', async () => {
     const res = await apiTesting.app.inject({
       method: 'GET',
       url: '/v1/getsubgraphswaps?limit=101'
@@ -304,7 +306,7 @@ describe('getsubgraphswaps', () => {
     expect(response.data.swaps.length).toStrictEqual(100)
   })
 
-  it('/v1/getsubgraphswaps?limit=X&next=Y - should paginate', async () => {
+  it.skip('/v1/getsubgraphswaps?limit=X&next=Y - should paginate', async () => {
     const [swap1And2, swap1]: any = await Promise.all([
       apiTesting.app.inject({
         method: 'GET',
@@ -355,7 +357,7 @@ describe('getsubgraphswaps - relying on caching', () => {
     await mockCache()
   })
 
-  it('/v1/getsubgraphswaps - should return 100 relatively quickly', async () => {
+  it.skip('/v1/getsubgraphswaps - should return 100 relatively quickly', async () => {
     // When getsubgraphswaps query is made
     const msStart = Date.now()
     const res = await apiTesting.app.inject({


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Skip flaky tests that are getting in the way of PRs

#### Additional comments?:
- Due to legacy-api tests' reliance on ocean prod, any dip in ocean's performance (region-specific, likely due to increased traffic) would result in the tests failing. Hence skipping the tests for now to prevent repeated CI failures on every PR and marking a TODO for addressing the underlying issue.