### PR TITLE
chore(workflows): Refactor docker build to build-push-action

### DIFF
--- a/.github/scripts/release-ecr-tags.js
+++ b/.github/scripts/release-ecr-tags.js
@@ -6,10 +6,6 @@
  */
 
 module.exports = ({ context }) => {
-  if (context.eventName === 'pull_request'){
-    return '2.1.0'
-  }
-
   if (context.eventName === 'release') {
     return getReleaseTag(context)
   }

--- a/.github/scripts/release-ecr-tags.js
+++ b/.github/scripts/release-ecr-tags.js
@@ -6,6 +6,10 @@
  */
 
 module.exports = ({ context }) => {
+  if (context.eventName === 'pull_request'){
+    return '2.0.0'
+  }
+
   if (context.eventName === 'release') {
     return getReleaseTag(context)
   }

--- a/.github/scripts/release-ecr-tags.js
+++ b/.github/scripts/release-ecr-tags.js
@@ -7,7 +7,7 @@
 
 module.exports = ({ context }) => {
   if (context.eventName === 'pull_request'){
-    return '2.0.0'
+    return '2.1.0'
   }
 
   if (context.eventName === 'release') {

--- a/.github/workflows/release-ecr.yml
+++ b/.github/workflows/release-ecr.yml
@@ -3,13 +3,17 @@ name: Release Apps for ECR
 on:
   release:
     types: [ published ]
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  APPS: 'legacy-api,ocean-api,playground-api,status-api,whale-api'
+  APPS: 'status-api'
 
 jobs:
   build:
@@ -19,7 +23,7 @@ jobs:
     environment: ECR Release Publishing
     strategy:
       matrix:
-        app: [ legacy-api, ocean-api, playground-api, status-api, whale-api ]
+        app: [ status-api ]
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
@@ -43,11 +47,13 @@ jobs:
           script: return require('./.github/scripts/release-ecr-tags.js')({ context })
           result-encoding: string
 
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: public.ecr.aws/x0i4b0k2
-          ECR_REPOSITORY: ${{ matrix.app }}
-          IMAGE_TAG: ${{ steps.ecr-tags.outputs.result }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+      - name: Build & Publish
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
+        with:
+          push: true
+          build-args: APP=${{ matrix.app }}
+          platforms: |
+            linux/amd64
+            linux/arm64
+          tags: |
+            public.ecr.aws/birthdayresearch/${{ matrix.app }}:${{ steps.ecr-tags.outputs.result }}

--- a/.github/workflows/release-ecr.yml
+++ b/.github/workflows/release-ecr.yml
@@ -57,5 +57,3 @@ jobs:
             linux/arm64
           tags: |
             public.ecr.aws/birthdayresearch/${{ matrix.app }}:${{ steps.ecr-tags.outputs.result }}
-            public.ecr.aws/birthdayresearch/${{ matrix.app }}:${{ steps.ecr-tags.outputs.result }}-amd
-            public.ecr.aws/birthdayresearch/${{ matrix.app }}:${{ steps.ecr-tags.outputs.result }}-arm

--- a/.github/workflows/release-ecr.yml
+++ b/.github/workflows/release-ecr.yml
@@ -3,17 +3,13 @@ name: Release Apps for ECR
 on:
   release:
     types: [ published ]
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  APPS: 'status-api'
+  APPS: 'legacy-api,ocean-api,playground-api,status-api,whale-api'
 
 jobs:
   build:
@@ -23,7 +19,7 @@ jobs:
     environment: ECR Release Publishing
     strategy:
       matrix:
-        app: [ status-api ]
+        app: [ legacy-api, ocean-api, playground-api, status-api, whale-api ]
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 

--- a/.github/workflows/release-ecr.yml
+++ b/.github/workflows/release-ecr.yml
@@ -57,3 +57,5 @@ jobs:
             linux/arm64
           tags: |
             public.ecr.aws/birthdayresearch/${{ matrix.app }}:${{ steps.ecr-tags.outputs.result }}
+            public.ecr.aws/birthdayresearch/${{ matrix.app }}:${{ steps.ecr-tags.outputs.result }}-amd
+            public.ecr.aws/birthdayresearch/${{ matrix.app }}:${{ steps.ecr-tags.outputs.result }}-arm


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Instead of executing docker command manually, attempt to build and push image via docker build-push-action to AWS ECR Public repo

Implement docker build and push image for other platforms
linux/amd64
linux/arm64

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/JellyfishSDK/jellyfish/issues/1432

#### Additional comments?:
