### PR TITLE
fix(whale-api): change to rely on defidcache instead of tokenMapper

### DIFF
--- a/apps/libs/caches/src/GlobalCache.ts
+++ b/apps/libs/caches/src/GlobalCache.ts
@@ -11,6 +11,7 @@ export enum CachePrefix {
   TOKEN_INFO_SYMBOL = 2,
   LOAN_SCHEME_INFO = 3,
   POOL_PAIRS = 4,
+  ALL_TOKEN_INFO = 5,
 }
 
 export class GlobalCache {

--- a/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
@@ -966,7 +966,7 @@ describe('latest dex prices', () => {
     // BURN is not a valid 'denomination' token
     await expect(controller.listDexPrices('BURN'))
       .rejects
-      .toThrowError('Unexpected error: could not find token with symbol \'BURN\'')
+      .toThrowError('Token \'BURN\' is invalid as it is not tradeable')
   })
 
   describe('param validation - denomination', () => {

--- a/apps/whale-api/src/module.api/poolpair.prices.service.ts
+++ b/apps/whale-api/src/module.api/poolpair.prices.service.ts
@@ -91,7 +91,7 @@ export class PoolPairPricesService {
   }
 
   private isUntradeableToken (token: TokenInfoWithId): boolean {
-    return token.isLPS || !token.isDAT || token.symbol === 'BURN'
+    return token.isLPS || !token.isDAT || token.symbol === 'BURN' || !token.tradeable
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Fixes a regression by changing dexPrices calculator to rely on defid instead of tokenMapper

#### Background
- Problem: token 49 (amzn/v1) and 89 (amzn) share the same `symbol` in `TokenMapper` due to #1532
  - dexPrices logic depends on a map indexed by `symbol` - there was an assumption that `symbols` would be unique
  - as there's a name collision (both have `symbol` = 'AMZN'), token 89 is overwritten by 49 in the dexPrices map, hence it never gets returned in the endpoint response
- Solution: change the dexPrices logic to rely solely on defid cache, remove any dependency on `TokenMapper`
  - This is also more of a __future-proof__ fix in case similar token splits occur

#### Which issue(s) does this PR fixes?:
Fixes a regression due to #1528 
