### PR TITLE
fix(legacy-api): fix failing tests due to token split

### DIFF
--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -99,7 +99,7 @@ it('/v1/listswaps', async () => {
   const v1JsonResponse = res.json()
   for (const [key, poolpair] of Object.entries(v1JsonResponse)) {
     // Verify all keys follow snake case
-    expect(key).toMatch(/^\w+(?:\.\w+)?_\w+$/)
+    expect(key).toMatch(/^\w+(?:\.\w+)?_\w+(\/v1)?$/) // '/v1' suffix from AMZN token split
 
     // Verify each swap object's fields
     expect(poolpair).toStrictEqual({
@@ -147,7 +147,7 @@ it('/v2/listswaps', async () => {
   const v2JsonResponse = res.json()
   for (const [key, poolpair] of Object.entries(v2JsonResponse)) {
     // Verify all keys follow snake case
-    expect(key).toMatch(/^\w+(?:\.\w+)?_\w+$/)
+    expect(key).toMatch(/^\w+(?:\.\w+)?_\w+(\/v1)?$/) // '/v1' suffix from AMZN token split
     // Verify each swap object's fields
     expect(poolpair).toStrictEqual({
       base_id: expect.any(String),

--- a/apps/legacy-api/src/controllers/PoolPairController.ts
+++ b/apps/legacy-api/src/controllers/PoolPairController.ts
@@ -454,7 +454,7 @@ function reformatPoolPairData (data: PoolPairData): LegacyPoolPairData {
     reserveA: data.tokenA.reserve,
     reserveB: data.tokenB.reserve,
     commission: Number(data.commission),
-    totalLiquidity: Number(data.totalLiquidity.usd),
+    totalLiquidity: Number(data.totalLiquidity.usd ?? 0),
     'reserveA/reserveB': Number(data.priceRatio.ab),
     'reserveB/reserveA': Number(data.priceRatio.ba),
     tradeEnabled: data.tradeEnabled,


### PR DESCRIPTION
#### What this PR does / why we need it:
- default totalLiquidity value to 0 (in case token is missing from ocean poolpair.totalLiquidity response)
- add '/v1' suffix to token name checking in legacy-api PoolPairController test

#### Which issue(s) does this PR fixes?:
Part of #1532
