### PR TITLE
chore(whale-api/cache): tune cache parameters for `stats.controller.ts`

### DIFF
--- a/apps/whale-api/src/module.api/_module.ts
+++ b/apps/whale-api/src/module.api/_module.ts
@@ -36,7 +36,7 @@ import { PoolPairPricesService } from './poolpair.prices.service'
  * Exposed ApiModule for public interfacing
  */
 @Module({
-  imports: [CacheModule.register()],
+  imports: [CacheModule.register({ max: 10000 })],
   controllers: [
     RpcController,
     AddressController,

--- a/apps/whale-api/src/module.api/stats.controller.ts
+++ b/apps/whale-api/src/module.api/stats.controller.ts
@@ -79,7 +79,7 @@ export class StatsController {
   private async getLoanInfo (): Promise<GetLoanInfoResult> {
     return await this.cachedGet('Controller.stats.getLoanInfo', async () => {
       return await this.rpcClient.loan.getLoanInfo()
-    }, 299)
+    }, 777)
   }
 
   private async getCachedBurnTotal (): Promise<BigNumber> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Tune `getLoanInfo` cache TTL due to the increased cost of running. Also expanded `CacheModule.options.max=10000` to increase the number of objects that can be cached on the CacheManager.