### PR TITLE
feat(docker): add commit hash version to docker container report

### DIFF
--- a/.github/scripts/release-report.js
+++ b/.github/scripts/release-report.js
@@ -5,18 +5,28 @@
  * along with some quality of life links.
  */
 module.exports = ({ context }) => {
-  const links = getContainerLinks(context)
+  const prLinks = getContainerPRLinks(context)
+  const hashLinks = getContainerHashLinks(context)
   return `
 
 Docker build preview for jellyfish/apps is ready!
           
 Built with commit ${context.sha}
 
- - ${links.join('\n - ')}
+ - ${prLinks.join('\n - ')}
+
+You can also get an immutable image with the commit hash
+
+ - ${hashLinks.join('\n - ')}
 `
 }
 
-function getContainerLinks ({ payload: { number } }) {
+function getContainerPRLinks({ payload: { number } }) {
   const apps = process.env.APPS.split(',')
   return apps.map(app => `ghcr.io/jellyfishsdk/${app}:pr-${number}`)
+}
+
+function getContainerHashLinks({ sha }) {
+  const apps = process.env.APPS.split(',')
+  return apps.map(app => `ghcr.io/jellyfishsdk/${app}:${sha}`)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

We want to make it easier to find immutable historic version of previously built containers by going into the report history and seeing links to containers tagged with commit hashes.

This change will make previous commit hashes more apparent since the PR tag mutates onto the latest built container and cannot serve as a historic reference.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1543
