### PR TITLE
fix(whale-api): network value being overwritten by joi

### DIFF
--- a/apps/whale-api/src/app.configuration.ts
+++ b/apps/whale-api/src/app.configuration.ts
@@ -29,11 +29,11 @@ export function AppConfiguration (): any {
 
 export function ENV_VALIDATION_SCHEMA (): any {
   return Joi.object({
-    NODE_ENV: Joi.string().valid('production'),
+    NODE_ENV: Joi.string().optional(),
     // Allows you to override whale endpoint version.
     WHALE_VERSION: Joi.string().default('v0.0'),
     WHALE_NETWORK: Joi.string().valid('mainnet', 'testnet', 'regtest', 'devnet').default('regtest'),
-    WHALE_DEFID_URL: Joi.string().required(),
+    WHALE_DEFID_URL: Joi.string().optional(),
     WHALE_DATABASE_PROVIDER: Joi.string().optional(),
     WHALE_DATABASE_LEVEL_LOCATION: Joi.string().optional()
   })

--- a/apps/whale-api/src/app.configuration.ts
+++ b/apps/whale-api/src/app.configuration.ts
@@ -30,8 +30,7 @@ export function AppConfiguration (): any {
 export function ENV_VALIDATION_SCHEMA (): any {
   return Joi.object({
     NODE_ENV: Joi.string().optional(),
-    // Allows you to override whale endpoint version.
-    WHALE_VERSION: Joi.string().default('v0.0'),
+    WHALE_VERSION: Joi.string().optional(),
     WHALE_NETWORK: Joi.string().valid('mainnet', 'testnet', 'regtest', 'devnet').default('regtest'),
     WHALE_DEFID_URL: Joi.string().optional(),
     WHALE_DATABASE_PROVIDER: Joi.string().optional(),

--- a/apps/whale-api/src/app.configuration.ts
+++ b/apps/whale-api/src/app.configuration.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi'
+
 /**
  * AppConfiguration declares a dictionary for a deeply configurable DeFi whale setup.
  * `process.env` resolves env variable at service initialization and allows setting of default.
@@ -23,4 +25,16 @@ export function AppConfiguration (): any {
       }
     }
   }
+}
+
+export function ENV_VALIDATION_SCHEMA (): any {
+  return Joi.object({
+    NODE_ENV: Joi.string().valid('production'),
+    // Allows you to override whale endpoint version.
+    WHALE_VERSION: Joi.string().default('v0.0'),
+    WHALE_NETWORK: Joi.string().valid('mainnet', 'testnet', 'regtest', 'devnet').default('regtest'),
+    WHALE_DEFID_URL: Joi.string().required(),
+    WHALE_DATABASE_PROVIDER: Joi.string().optional(),
+    WHALE_DATABASE_LEVEL_LOCATION: Joi.string().optional()
+  })
 }

--- a/apps/whale-api/src/app.module.ts
+++ b/apps/whale-api/src/app.module.ts
@@ -3,7 +3,7 @@ import { DynamicModule, Module } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { ScheduleModule } from '@nestjs/schedule'
 
-import { AppConfiguration } from './app.configuration'
+import { AppConfiguration, ENV_VALIDATION_SCHEMA } from './app.configuration'
 
 import { ApiModule } from './module.api/_module'
 import { DatabaseModule } from './module.database/_module'
@@ -15,7 +15,6 @@ import { NestFastifyApplication } from '@nestjs/platform-fastify'
 import { NestFactory } from '@nestjs/core'
 import { newFastifyAdapter } from './fastify'
 import { AbstractHttpAdapter } from '@nestjs/core/adapters/http-adapter'
-import * as Joi from 'joi'
 
 @Module({})
 export class AppModule {
@@ -81,10 +80,4 @@ export class AppModule {
     const defaultVersion = `v${major}.${minor}`
     return app.get(ConfigService).get<string>('version', defaultVersion)
   }
-}
-
-function ENV_VALIDATION_SCHEMA (): any {
-  return Joi.object({
-    network: Joi.string().valid('mainnet', 'testnet', 'regtest', 'devnet').default('regtest')
-  })
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Fixes the `network` config being overwritten by Joi schema validation
- NestJS's ConfigModule expects the Joi schema to validate `process.env`, not the app config object

#### In Detail
- ConfigModule will use `Joi.object({ network: Joi.string().default('regtest')})` to validate process.env
- It checks `network` and sees that it's missing from `process.env` (as the env variable is `WHALE_NETWORK`)
- So it sets the default value provided - `network: 'regtest'` - in ConfigService, overwriting the value provided by `load: [AppConfiguration]`

#### Issue:

#### 1. Setting the default to `helloworld`
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/31790206/173752501-2b18adf0-313c-4910-a973-2c2e94132ab1.png">


#### 2. Notice that all the urls are prefixed with `helloworld`, even though `WHALE_NETWORK` env variable is set to 'regtest' 
<img width="810" alt="image" src="https://user-images.githubusercontent.com/31790206/173752360-34f2bbdd-9642-4b60-a08e-252e602243d5.png">
<img width="607" alt="image" src="https://user-images.githubusercontent.com/31790206/173752623-64699a7c-61d1-4e54-90fc-323253bdd4df.png">
