### PR TITLE
refactor(poolpairs): refactor poolpairs and token services to use cached defid

### DIFF
--- a/apps/whale-api/src/e2e.module.ts
+++ b/apps/whale-api/src/e2e.module.ts
@@ -10,6 +10,8 @@ import waitForExpect from 'wait-for-expect'
 import { addressToHid } from './module.api/address.controller'
 import { ScriptAggregationMapper } from './module.model/script.aggregation'
 import { TestingGroup } from '@defichain/jellyfish-testing'
+import { DeFiDCache } from './module.api/cache/defid.cache'
+import { CacheModule } from '@nestjs/common'
 
 /**
  * Configures an end-to-end testing app integrated with all modules.
@@ -59,7 +61,13 @@ export async function stopTestingApp (container: MasterNodeRegTestContainer | Te
 
 async function createTestingModule (url: string): Promise<TestingModule> {
   return await Test.createTestingModule({
-    imports: [AppModule.forRoot('memory')]
+    imports: [
+      CacheModule.register({ max: 10_000 }),
+      AppModule.forRoot('memory')
+    ],
+    providers: [
+      DeFiDCache
+    ]
   })
     .overrideProvider(ConfigService).useValue(new TestConfigService(url))
     .compile()

--- a/apps/whale-api/src/module.api/_module.ts
+++ b/apps/whale-api/src/module.api/_module.ts
@@ -36,7 +36,7 @@ import { PoolPairPricesService } from './poolpair.prices.service'
  * Exposed ApiModule for public interfacing
  */
 @Module({
-  imports: [CacheModule.register({ max: 10000 })],
+  imports: [CacheModule.register({ max: 10_000 })],
   controllers: [
     RpcController,
     AddressController,
@@ -54,10 +54,19 @@ import { PoolPairPricesService } from './poolpair.prices.service'
     LoanController
   ],
   providers: [
-    { provide: APP_PIPE, useClass: ApiValidationPipe },
+    {
+      provide: APP_PIPE,
+      useClass: ApiValidationPipe
+    },
     // APP_INTERCEPTOR are only activated for /v* paths
-    { provide: APP_INTERCEPTOR, useClass: ResponseInterceptor },
-    { provide: APP_INTERCEPTOR, useClass: ExceptionInterceptor },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ResponseInterceptor
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ExceptionInterceptor
+    },
     {
       provide: 'NETWORK',
       useFactory: (configService: ConfigService): NetworkName => {

--- a/apps/whale-api/src/module.api/cache/defid.cache.spec.ts
+++ b/apps/whale-api/src/module.api/cache/defid.cache.spec.ts
@@ -42,7 +42,6 @@ describe('getPoolPairInfo', () => {
     await createPoolPair(container, 'A', 'C') // 5
     await createPoolPair(container, 'B', 'C') // 6
 
-    // TODO(canonbrother): add listpoolpairs in @defi/testing
     const poolPairResult = await container.call('listpoolpairs')
     for (const k in poolPairResult) {
       await defiCache.getPoolPairInfo(k)

--- a/apps/whale-api/src/module.api/cache/defid.cache.ts
+++ b/apps/whale-api/src/module.api/cache/defid.cache.ts
@@ -89,14 +89,28 @@ export class DeFiDCache extends GlobalCache {
    * @param {string} id - id of the poolPair
    */
   async getPoolPairInfoFromPoolPairs (id: string): Promise<PoolPairInfo | undefined> {
-    const poolPairsById = await this.listPoolPairs(60)
+    const poolPairsById = await this.getCachedPoolPairsResult(60)
     if (poolPairsById === undefined) {
       return undefined
     }
     return poolPairsById[id]
   }
 
-  async listPoolPairs (ttlSeconds: number): Promise<PoolPairsResult | undefined> {
+  async getPoolPairs (): Promise<PoolPairInfoWithId[]> {
+    const poolPairInfoWithIds: PoolPairInfoWithId[] = []
+
+    const results = await this.getCachedPoolPairsResult(60)
+    if (results === undefined) {
+      return []
+    }
+
+    for (const [id, token] of Object.entries(results)) {
+      poolPairInfoWithIds.push({ ...token, id })
+    }
+    return poolPairInfoWithIds
+  }
+
+  private async getCachedPoolPairsResult (ttlSeconds: number): Promise<PoolPairsResult | undefined> {
     return await this.get<PoolPairsResult>(CachePrefix.POOL_PAIRS, '*', this.fetchPoolPairs.bind(this),
       {
         ttl: ttlSeconds
@@ -152,5 +166,9 @@ export class DeFiDCache extends GlobalCache {
 
 // To remove if/when jellyfish-api-core supports IDs on tokenInfo, since it's commonly required
 export interface TokenInfoWithId extends TokenInfo {
+  id: string
+}
+
+export interface PoolPairInfoWithId extends PoolPairInfo {
   id: string
 }

--- a/apps/whale-api/src/module.api/poolpair.controller.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.ts
@@ -195,7 +195,13 @@ export class PoolPairController {
   }
 }
 
-function mapPoolPair (id: string, info: PoolPairInfo, totalLiquidityUsd?: BigNumber, apr?: PoolPairData['apr'], volume?: PoolPairData['volume']): PoolPairData {
+function mapPoolPair (
+  id: string,
+  info: PoolPairInfo,
+  totalLiquidityUsd?: BigNumber,
+  apr?: PoolPairData['apr'],
+  volume?: PoolPairData['volume']
+): PoolPairData {
   const [symbolA, symbolB] = info.symbol.split('-')
 
   return {

--- a/apps/whale-api/src/module.api/poolpair.prices.service.ts
+++ b/apps/whale-api/src/module.api/poolpair.prices.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { PoolSwapPathFindingService } from './poolswap.pathfinding.service'
-import { TokenMapper } from '../module.model/token'
 import { DeFiDCache, TokenInfoWithId } from './cache/defid.cache'
 import { DexPricesResult, TokenIdentifier } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { parseDisplaySymbol } from './token.controller'
@@ -13,7 +12,6 @@ export class PoolPairPricesService {
 
   constructor (
     private readonly poolSwapPathfindingService: PoolSwapPathFindingService,
-    private readonly tokenMapper: TokenMapper,
     private readonly defidCache: DeFiDCache,
     protected readonly cache: SemaphoreCache
   ) {

--- a/apps/whale-api/src/module.api/poolpair.service.ts
+++ b/apps/whale-api/src/module.api/poolpair.service.ts
@@ -10,8 +10,6 @@ import {
   SwapType
 } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { getBlockSubsidy } from './subsidy'
-import { BlockMapper } from '../module.model/block'
-import { TokenMapper } from '../module.model/token'
 import { PoolSwapAggregated, PoolSwapAggregatedMapper } from '../module.model/pool.swap.aggregated'
 import { PoolSwapAggregatedInterval } from '../module.indexer/model/dftx/pool.swap.aggregated'
 import { TransactionVoutMapper } from '../module.model/transaction.vout'
@@ -40,9 +38,7 @@ export class PoolPairService {
     protected readonly deFiDCache: DeFiDCache,
     protected readonly cache: SemaphoreCache,
     protected readonly poolSwapAggregatedMapper: PoolSwapAggregatedMapper,
-    protected readonly voutMapper: TransactionVoutMapper,
-    protected readonly tokenMapper: TokenMapper,
-    protected readonly blockMapper: BlockMapper
+    protected readonly voutMapper: TransactionVoutMapper
   ) {
   }
 
@@ -149,9 +145,9 @@ export class PoolPairService {
     })
   }
 
-  private async getTokenUSDValue (id: number): Promise<BigNumber | undefined> {
+  private async getTokenUSDValue (id: string): Promise<BigNumber | undefined> {
     return await this.cache.get<BigNumber>(`PRICE_FOR_TOKEN_${id}`, async () => {
-      const tokenInfo = await this.tokenMapper.getByTokenId(id)
+      const tokenInfo = await this.deFiDCache.getTokenInfo(id)
       const token = tokenInfo?.symbol
 
       if (token === undefined) {
@@ -201,7 +197,7 @@ export class PoolPairService {
 
         let volume = 0
         for (const tokenId in aggregated) {
-          const tokenPrice = await this.getTokenUSDValue(parseInt(tokenId)) ?? new BigNumber(0)
+          const tokenPrice = await this.getTokenUSDValue(tokenId) ?? new BigNumber(0)
           volume += tokenPrice.toNumber() * aggregated[tokenId]
         }
 
@@ -221,7 +217,7 @@ export class PoolPairService {
     let value = 0
 
     for (const tokenId in amounts) {
-      const tokenPrice = await this.getTokenUSDValue(parseInt(tokenId)) ?? new BigNumber(0)
+      const tokenPrice = await this.getTokenUSDValue(tokenId) ?? new BigNumber(0)
       value += tokenPrice.toNumber() * Number.parseFloat(amounts[tokenId])
     }
     return value


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Part of https://github.com/JellyfishSDK/jellyfish/pull/1547 requirements, this brings forward underlying changes and move more services to solely use cached defid.