### PR TITLE
chore(whale-api): allow Index Swap to fail silently if PoolPair cannot be found

### DIFF
--- a/apps/whale-api/src/module.indexer/model/dftx/composite.swap.ts
+++ b/apps/whale-api/src/module.indexer/model/dftx/composite.swap.ts
@@ -1,16 +1,16 @@
 import { DfTxIndexer, DfTxTransaction } from './_abstract'
 import { CCompositeSwap, CompositeSwap, PoolId } from '@defichain/jellyfish-transaction'
 import { RawBlock } from '../_abstract'
-import { Inject, Injectable } from '@nestjs/common'
+import { Inject, Injectable, Logger } from '@nestjs/common'
 import { NetworkName } from '@defichain/jellyfish-network'
 import BigNumber from 'bignumber.js'
-import { IndexerError } from '../../error'
 import { PoolPairPathMapping } from './pool.pair.path.mapping'
 import { PoolSwapIndexer } from './pool.swap'
 
 @Injectable()
 export class CompositeSwapIndexer extends DfTxIndexer<CompositeSwap> {
   OP_CODE: number = CCompositeSwap.OP_CODE
+  private readonly logger = new Logger(CompositeSwapIndexer.name)
 
   constructor (
     private readonly poolSwapIndexer: PoolSwapIndexer,
@@ -55,6 +55,7 @@ export class CompositeSwapIndexer extends DfTxIndexer<CompositeSwap> {
       return [{ id: Number(pair.id) }]
     }
 
-    throw new IndexerError(`Pool for pair ${poolSwap.fromTokenId}, ${poolSwap.toTokenId} not found in PoolPairPathMapping`)
+    this.logger.error(`Pool for pair ${poolSwap.fromTokenId}, ${poolSwap.toTokenId} not found in PoolPairPathMapping`)
+    return []
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

In an effort to reduce the area of failure exposure on `apps/whale-api` and cascading fail. This PR make PoolSwap indexing failable at production. 

#### Which issue(s) does this PR fixes?:

Elevate the issues on https://github.com/JellyfishSDK/jellyfish/issues/1583

#### Additional comments?:

- Keeping it here, might not merge this at all.