### PR TITLE
chore(whale-api): /stats/burn BurnInfo remapped to BurnData due to upstream standards drift

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -12,6 +12,7 @@
       <w>ancestorsize</w>
       <w>anchorquorum</w>
       <w>anyonecanpay</w>
+      <w>auctionburn</w>
       <w>bayfrontgardensheight</w>
       <w>bayfrontheight</w>
       <w>bayfrontmarinaheight</w>
@@ -65,7 +66,10 @@
       <w>descendantsize</w>
       <w>destroyloanscheme</w>
       <w>devnet</w>
+      <w>dexfeetokens</w>
       <w>dfip</w>
+      <w>dfipaybackfee</w>
+      <w>dfipaybacktokens</w>
       <w>dftx</w>
       <w>dockerignore</w>
       <w>dockerode</w>
@@ -190,7 +194,10 @@
       <w>numequal</w>
       <w>numequalverify</w>
       <w>numnotequal</w>
+      <w>paybackburn</w>
+      <w>paybackfees</w>
       <w>paybackloan</w>
+      <w>paybacktokens</w>
       <w>paytxfee</w>
       <w>pooledtx</w>
       <w>poolpair</w>

--- a/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
+++ b/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
@@ -9,7 +9,7 @@ import {
 import { WhaleApiClientProvider } from '../../providers/WhaleApiClientProvider'
 import BigNumber from 'bignumber.js'
 import { WhaleApiClient } from '@defichain/whale-api-client'
-import { StatsData } from '@defichain/whale-api-client/dist/api/stats'
+import { BurnData, StatsData } from '@defichain/whale-api-client/dist/api/stats'
 import { get } from 'lodash'
 
 // region - Needs to be kept in sync with defi-stats-api-master
@@ -133,7 +133,7 @@ export class MainnetLegacyStatsProvider {
   }
 
   async getBurnInfo (): Promise<LegacyBurnInfo> {
-    const burnInfo: any = await this.api.stats.getBurn()
+    const burnInfo: BurnData = await this.api.stats.getBurn()
     return {
       address: burnInfo.address,
       amount: new BigNumber(burnInfo.amount).toFixed(DECIMAL_PLACES),

--- a/apps/whale-api/src/module.api/stats.controller.ts
+++ b/apps/whale-api/src/module.api/stats.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common'
-import { StatsData, SupplyData } from '@defichain/whale-api-client/dist/api/stats'
+import { BurnData, StatsData, SupplyData } from '@defichain/whale-api-client/dist/api/stats'
 import { SemaphoreCache } from '@defichain-apps/libs/caches'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { BlockMapper } from '../module.model/block'
@@ -66,6 +66,29 @@ export class StatsController {
       total: total.gt(max) ? max : total.toNumber(), // as emission burn is taken into the 1.2b calculation post eunos
       burned: burnedTotal.toNumber(),
       circulating: circulating.toNumber()
+    }
+  }
+
+  /**
+   * Remapped from BurnInfo into BurnData due to upstream standards drift.
+   */
+  @Get('/burn')
+  async getBurn (): Promise<BurnData> {
+    const burnInfo = await this.getBurnInfo()
+    return {
+      address: burnInfo.address,
+      amount: burnInfo.amount.toNumber(),
+      tokens: burnInfo.tokens,
+      feeburn: burnInfo.feeburn.toNumber(),
+      emissionburn: burnInfo.emissionburn.toNumber(),
+      auctionburn: burnInfo.auctionburn.toNumber(),
+      paybackburn: burnInfo.paybackburn.toNumber(),
+      dexfeetokens: burnInfo.dexfeetokens,
+      dfipaybackfee: burnInfo.dfipaybackfee.toNumber(),
+      dfipaybacktokens: burnInfo.dfipaybacktokens,
+      paybackfees: burnInfo.paybackfees,
+      paybacktokens: burnInfo.paybacktokens,
+      dfip2203: burnInfo.dfip2203
     }
   }
 

--- a/apps/whale-api/src/module.api/stats.controller.ts
+++ b/apps/whale-api/src/module.api/stats.controller.ts
@@ -92,7 +92,6 @@ export class StatsController {
     }
   }
 
-  @Get('/burn')
   async getBurnInfo (): Promise<BurnInfo> {
     return await this.cachedGet('Controller.stats.getBurnInfo', async () => {
       return await this.rpcClient.account.getBurnInfo()

--- a/packages/whale-api-client/src/api/stats.ts
+++ b/packages/whale-api-client/src/api/stats.ts
@@ -1,7 +1,4 @@
-import { account } from '@defichain/jellyfish-api-core'
 import { WhaleApiClient } from '../whale.api.client'
-
-export type BurnData = account.BurnInfo
 
 export class Stats {
   constructor (private readonly client: WhaleApiClient) {
@@ -122,4 +119,56 @@ export interface SupplyData {
    * Total - Burned = Circulating
    */
   circulating: number
+}
+
+export interface BurnData {
+  address: string
+  /**
+   * Amount send to burn address
+   */
+  amount: number
+  /**
+   * Token amount send to burn address; formatted as AMOUNT@SYMBOL
+   */
+  tokens: string[]
+  /**
+   * Amount collected via fee burn
+   */
+  feeburn: number
+  /**
+   * Amount collected via emission burn
+   */
+  emissionburn: number
+  /**
+   * Amount collected via auction burn
+   */
+  auctionburn: number
+  /**
+   * Value of burn after payback
+   */
+  paybackburn: number
+  /**
+   * Formatted as AMOUNT@SYMBOL
+   */
+  dexfeetokens: string[]
+  /**
+   * Amount of DFI collected from penalty resulting from paying DUSD using DFI
+   */
+  dfipaybackfee: number
+  /**
+   * Amount of tokens that are paid back; formatted as AMOUNT@SYMBOL
+   */
+  dfipaybacktokens: string[]
+  /**
+   * Amount of paybacks
+   */
+  paybackfees: string[]
+  /**
+   * Amount of tokens that are paid back
+   */
+  paybacktokens: string[]
+  /**
+   * Amount of tokens burned due to futureswap
+   */
+  dfip2203: string[]
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Partial fix for #1589 to remap `BurnInfo` from packages/jellyfish-api-core in `/stats/burn` to `BurnData` in packages/whale-api-client to prevent standards drift and causing breaking changes on whale due to upstream changes.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Partial fix for #1589, still need to wait for the `defid:2.9.x` change to be merged in to fix the real issue.

